### PR TITLE
Remove problematic require, useless guards and fix some deprecations

### DIFF
--- a/action.php
+++ b/action.php
@@ -8,10 +8,6 @@
  * @author  lisps
  */
 
-if (!defined('DOKU_INC')) die();
-if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC . 'lib/plugins/');
-require_once (DOKU_PLUGIN . 'action.php');
-
 class action_plugin_tagfilter extends DokuWiki_Action_Plugin {
 	/**
 	 * Register the eventhandlers

--- a/action.php
+++ b/action.php
@@ -22,7 +22,7 @@ class action_plugin_tagfilter extends DokuWiki_Action_Plugin {
 		global $JSINFO;
 		global $INPUT;
 	    // filter for ft* in GET
-	    $f = create_function('$value', 'return strpos($value,"tf") === 0;');
+	    $f = function($value) { return strpos($value,"tf") === 0; };
 	    $get_tagfilter = array_filter(array_keys($_GET),$f);
 
 		//filter for ft<key>_<label> and add it to JSINFO to select it via JavaScript

--- a/helper.php
+++ b/helper.php
@@ -251,8 +251,8 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin {
 		$tags = explode(' ',$tag);
 		$this->startPageSearch($ns);
 		foreach($tags as $t){
-			if($t{0} == '+') $this->addAndTag(substr($t,1));
-			elseif($t{0} == '-') $this->addSubTag(substr($t,1));
+			if($t[0] == '+') $this->addAndTag(substr($t,1));
+			elseif($t[0] == '-') $this->addSubTag(substr($t,1));
 			else $this->addOrTag($t);
 		}
 		return $this->getPages();

--- a/helper.php
+++ b/helper.php
@@ -6,14 +6,6 @@
  * @author  lisps
  */
 
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
-
-if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
-if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
-
-require_once(DOKU_INC.'inc/indexer.php');
-
 class helper_plugin_tagfilter extends DokuWiki_Plugin {
 	/**
 	 * 

--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -1,6 +1,4 @@
 <?php
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
 
 class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin 
 {


### PR DESCRIPTION
In particular, this removes the unnecessary `require_once(DOKU_INC.'inc/indexer.php');` which would lead to a fatal error when the upcoming refactoring splitbrain/dokuwiki#2943 is merged into DokuWiki master.

Also, it removes some unnecessary guards and fixes some deprecations that were throwing annoying warnings. See the respective commits.