### PR TITLE
Fix travis by using correct phpunit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/tr
 install: sh travis.sh
 script: 
   - cd _test
-  - phpunit --group plugin_tagfilter
+  - ./phpunit.phar --group plugin_tagfilter


### PR DESCRIPTION
This uses the phpunit.phar downloaded by @splitbrain's travis.sh that
is compatible with DokuWiki and the respective PHP version.