### PR TITLE
php8 issets, refactoring, reformatting

### DIFF
--- a/_test/ajax.test.php
+++ b/_test/ajax.test.php
@@ -1,38 +1,41 @@
 <?php
+
+use dokuwiki\Extension\Event;
+
 /**
  * @group plugin_tagfilter
  * @group plugins
  */
 class plugin_tagfilter_ajax_test extends DokuWikiTest {
 
-    protected $pluginsEnabled = array(
+    protected $pluginsEnabled = [
         'tag','tagfilter','pagelist'
-    );
+    ];
     public function setup() : void {
         parent::setup();
         $this->_createPages();
     }
 
-    
+
     public function test_ajax_request_notags() {
         global $INPUT;
         global $lang;
-        
+
         $INPUT->set('id', 0);
         $INPUT->set('form',json_encode(array()));
         $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
         $INPUT->set('flags',json_encode(array()));
         $INPUT->set('pagesearch',json_encode(array()));
-        
+
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        trigger_event('AJAX_CALL_UNKNOWN',$data);
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
         $response = ob_get_contents();
         ob_end_clean();
         error_reporting($er);
-        
+
         if(isset($lang['nothingfound'])) {
             $this->assertEquals('{"id":0,"text":"<i>Nothing was found.<\/i>"}', $response);
         }
@@ -40,22 +43,22 @@ class plugin_tagfilter_ajax_test extends DokuWikiTest {
             $this->assertEquals('{"id":0,"text":"<i><\/i>"}', $response);
         }
     }
-    
+
     public function test_ajax_request_alltags() {
         global $INPUT;
-    
+
         $INPUT->set('id', 0);
         $INPUT->set('form','[["cat1:blorg","cat2:a","cat3:1","cat2:b","cat3:2"]]');
         $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
         $INPUT->set('flags',json_encode(array()));
         $INPUT->set('pagesearch',json_encode(array()));
-    
+
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        trigger_event('AJAX_CALL_UNKNOWN',$data);
-        
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
+
         $response1 = ob_get_contents();
         $response2 = json_decode($response1);
         $response = (array)$response2;
@@ -64,54 +67,54 @@ class plugin_tagfilter_ajax_test extends DokuWikiTest {
         if(!isset($response['text'])){
             var_dump(array($response1,$response2,$response));
         } else {
-        
-            $this->assertContains('id=test:plugin_tagfilter:tags:tagpage1', $response['text']);
-            $this->assertContains('id=test:plugin_tagfilter:tags:tagpage2', $response['text']);
+
+            $this->assertStringContainsString('id=test:plugin_tagfilter:tags:tagpage1', $response['text']);
+            $this->assertStringContainsString('id=test:plugin_tagfilter:tags:tagpage2', $response['text']);
         }
     }
-    
+
     public function test_ajax_request_onepage() {
         global $INPUT;
-    
+
         $INPUT->set('id', 0);
         $INPUT->set('form','[["cat1:blorg"],["cat3:2"]]');
         $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
         $INPUT->set('flags',json_encode(array()));
         $INPUT->set('pagesearch',json_encode(array()));
-        
+
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        trigger_event('AJAX_CALL_UNKNOWN',$data);
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
         $response = (array)json_decode(ob_get_contents());
         ob_end_clean();
         error_reporting($er);
         $this->assertFalse(strpos($response['text'], 'id=test:plugin_tagfilter:tags:tagpage1') !== false);
-        $this->assertContains('id=test:plugin_tagfilter:tags:tagpage2', $response['text']);
-    
+        $this->assertStringContainsString('id=test:plugin_tagfilter:tags:tagpage2', $response['text']);
+
     }
-    
+
     public function test_ajax_request_pagesearch() {
         global $INPUT;
-    
+
         $INPUT->set('id', 0);
         $INPUT->set('form','[["cat1:blorg"]]');
         $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
         $INPUT->set('flags',json_encode(array()));
         $INPUT->set('pagesearch',json_encode(array('test:plugin_tagfilter:tags:tagpage2')));
-    
+
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        trigger_event('AJAX_CALL_UNKNOWN',$data);
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
         $response = (array)json_decode(ob_get_contents());
         ob_end_clean();
         error_reporting($er);
         $this->assertFalse(strpos($response['text'], 'id=test:plugin_tagfilter:tags:tagpage1') !== false);
-        $this->assertContains('id=test:plugin_tagfilter:tags:tagpage2', $response['text']);
-    
+        $this->assertStringContainsString('id=test:plugin_tagfilter:tags:tagpage2', $response['text']);
+
     }
 
     protected function _createPages() {
@@ -120,12 +123,12 @@ class plugin_tagfilter_ajax_test extends DokuWikiTest {
         saveWikiText('test:plugin_tagfilter:start',  '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*}}', 'test');
         saveWikiText('test:plugin_tagfilter:start2', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&pagesearch}}', 'test');
         saveWikiText('test:plugin_tagfilter:start3', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&multi}}', 'test');
-        
+
         idx_addPage('test:plugin_tagfilter:tags:tagpage1',false);
         idx_addPage('test:plugin_tagfilter:tags:tagpage2',false);
     }
-    
-    
-    
+
+
+
 
 }

--- a/_test/ajax.test.php
+++ b/_test/ajax.test.php
@@ -6,66 +6,70 @@ use dokuwiki\Extension\Event;
  * @group plugin_tagfilter
  * @group plugins
  */
-class plugin_tagfilter_ajax_test extends DokuWikiTest {
+class plugin_tagfilter_ajax_test extends DokuWikiTest
+{
 
     protected $pluginsEnabled = [
-        'tag','tagfilter','pagelist'
+        'tag', 'tagfilter', 'pagelist'
     ];
-    public function setup() : void {
+
+    public function setup(): void
+    {
         parent::setup();
         $this->_createPages();
     }
 
 
-    public function test_ajax_request_notags() {
+    public function test_ajax_request_notags()
+    {
         global $INPUT;
         global $lang;
 
         $INPUT->set('id', 0);
-        $INPUT->set('form',json_encode(array()));
-        $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
-        $INPUT->set('flags',json_encode(array()));
-        $INPUT->set('pagesearch',json_encode(array()));
+        $INPUT->set('form', json_encode(array()));
+        $INPUT->set('ns', json_encode('test:plugin_tagfilter:tags'));
+        $INPUT->set('flags', json_encode(array()));
+        $INPUT->set('pagesearch', json_encode(array()));
 
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN', $data);
         $response = ob_get_contents();
         ob_end_clean();
         error_reporting($er);
 
-        if(isset($lang['nothingfound'])) {
+        if (isset($lang['nothingfound'])) {
             $this->assertEquals('{"id":0,"text":"<i>Nothing was found.<\/i>"}', $response);
-        }
-        else {
+        } else {
             $this->assertEquals('{"id":0,"text":"<i><\/i>"}', $response);
         }
     }
 
-    public function test_ajax_request_alltags() {
+    public function test_ajax_request_alltags()
+    {
         global $INPUT;
 
         $INPUT->set('id', 0);
-        $INPUT->set('form','[["cat1:blorg","cat2:a","cat3:1","cat2:b","cat3:2"]]');
-        $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
-        $INPUT->set('flags',json_encode(array()));
-        $INPUT->set('pagesearch',json_encode(array()));
+        $INPUT->set('form', '[["cat1:blorg","cat2:a","cat3:1","cat2:b","cat3:2"]]');
+        $INPUT->set('ns', json_encode('test:plugin_tagfilter:tags'));
+        $INPUT->set('flags', json_encode(array()));
+        $INPUT->set('pagesearch', json_encode(array()));
 
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN', $data);
 
         $response1 = ob_get_contents();
         $response2 = json_decode($response1);
         $response = (array)$response2;
         ob_end_clean();
         error_reporting($er);
-        if(!isset($response['text'])){
-            var_dump(array($response1,$response2,$response));
+        if (!isset($response['text'])) {
+            var_dump(array($response1, $response2, $response));
         } else {
 
             $this->assertStringContainsString('id=test:plugin_tagfilter:tags:tagpage1', $response['text']);
@@ -73,20 +77,21 @@ class plugin_tagfilter_ajax_test extends DokuWikiTest {
         }
     }
 
-    public function test_ajax_request_onepage() {
+    public function test_ajax_request_onepage()
+    {
         global $INPUT;
 
         $INPUT->set('id', 0);
-        $INPUT->set('form','[["cat1:blorg"],["cat3:2"]]');
-        $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
-        $INPUT->set('flags',json_encode(array()));
-        $INPUT->set('pagesearch',json_encode(array()));
+        $INPUT->set('form', '[["cat1:blorg"],["cat3:2"]]');
+        $INPUT->set('ns', json_encode('test:plugin_tagfilter:tags'));
+        $INPUT->set('flags', json_encode(array()));
+        $INPUT->set('pagesearch', json_encode(array()));
 
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN', $data);
         $response = (array)json_decode(ob_get_contents());
         ob_end_clean();
         error_reporting($er);
@@ -95,20 +100,21 @@ class plugin_tagfilter_ajax_test extends DokuWikiTest {
 
     }
 
-    public function test_ajax_request_pagesearch() {
+    public function test_ajax_request_pagesearch()
+    {
         global $INPUT;
 
         $INPUT->set('id', 0);
-        $INPUT->set('form','[["cat1:blorg"]]');
-        $INPUT->set('ns',json_encode('test:plugin_tagfilter:tags'));
-        $INPUT->set('flags',json_encode(array()));
-        $INPUT->set('pagesearch',json_encode(array('test:plugin_tagfilter:tags:tagpage2')));
+        $INPUT->set('form', '[["cat1:blorg"]]');
+        $INPUT->set('ns', json_encode('test:plugin_tagfilter:tags'));
+        $INPUT->set('flags', json_encode(array()));
+        $INPUT->set('pagesearch', json_encode(array('test:plugin_tagfilter:tags:tagpage2')));
 
         $er = error_reporting();
         error_reporting($er ^ E_STRICT);
         ob_start();
         $data = 'plugin_tagfilter';
-        Event::createAndTrigger('AJAX_CALL_UNKNOWN',$data);
+        Event::createAndTrigger('AJAX_CALL_UNKNOWN', $data);
         $response = (array)json_decode(ob_get_contents());
         ob_end_clean();
         error_reporting($er);
@@ -117,18 +123,17 @@ class plugin_tagfilter_ajax_test extends DokuWikiTest {
 
     }
 
-    protected function _createPages() {
-        saveWikiText('test:plugin_tagfilter:tags:tagpage1', '==== Tagpage1 ===='.DOKU_LF.'{{tag>cat1:blorg cat2:a cat3:1}}', 'test');
-        saveWikiText('test:plugin_tagfilter:tags:tagpage2', '==== Tagpage2 ===='.DOKU_LF.'{{tag>cat1:blorg cat2:b cat3:2}}', 'test');
-        saveWikiText('test:plugin_tagfilter:start',  '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*}}', 'test');
+    protected function _createPages()
+    {
+        saveWikiText('test:plugin_tagfilter:tags:tagpage1', '==== Tagpage1 ====' . DOKU_LF . '{{tag>cat1:blorg cat2:a cat3:1}}', 'test');
+        saveWikiText('test:plugin_tagfilter:tags:tagpage2', '==== Tagpage2 ====' . DOKU_LF . '{{tag>cat1:blorg cat2:b cat3:2}}', 'test');
+        saveWikiText('test:plugin_tagfilter:start', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*}}', 'test');
         saveWikiText('test:plugin_tagfilter:start2', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&pagesearch}}', 'test');
         saveWikiText('test:plugin_tagfilter:start3', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&multi}}', 'test');
 
-        idx_addPage('test:plugin_tagfilter:tags:tagpage1',false);
-        idx_addPage('test:plugin_tagfilter:tags:tagpage2',false);
+        idx_addPage('test:plugin_tagfilter:tags:tagpage1', false);
+        idx_addPage('test:plugin_tagfilter:tags:tagpage2', false);
     }
-
-
 
 
 }

--- a/_test/syntax.test.php
+++ b/_test/syntax.test.php
@@ -5,36 +5,39 @@
  */
 class plugin_tagfilter_syntax_test extends DokuWikiTest {
 
-    protected $pluginsEnabled = array(
+    protected $pluginsEnabled = [
         'tag','tagfilter'
-    );
+    ];
     public function setup() : void {
         parent::setup();
         $this->_createPages();
     }
 
-    
+
     public function test_basic_syntax() {
+        global $ID, $INFO;
+        $ID = 'test:plugin_tagfilter:start';
+        $INFO = pageinfo(); //filepath is used
         $xhtml = p_wiki_xhtml('test:plugin_tagfilter:start');
         $doc = phpQuery::newDocument($xhtml);
 
         $form = pq('form[data-plugin=tagfilter]',$doc);
-        
+
         //echo $form;
         $select = pq('select',$form);
-        $this->assertTrue($select->length() === 3);
+        $this->assertTrue($select->count() === 3);
         $this->assertEquals('T1', $select->eq(0)->attr('name'));
         $this->assertEquals('T2', $select->eq(1)->attr('name'));
         $this->assertEquals('T3', $select->eq(2)->attr('name'));
 
-        $this->assertEquals('T1 choosing', $select->eq(0)->attr('data-placeholder'));
-        $this->assertEquals('T2 choosing', $select->eq(1)->attr('data-placeholder'));
-        $this->assertEquals('T3 choosing', $select->eq(2)->attr('data-placeholder'));
+        $this->assertEquals('T1 selection', $select->eq(0)->attr('data-placeholder'));
+        $this->assertEquals('T2 selection', $select->eq(1)->attr('data-placeholder'));
+        $this->assertEquals('T3 selection', $select->eq(2)->attr('data-placeholder'));
 
         $this->assertNull($select->eq(0)->attr('multiple'));
         $this->assertNull($select->eq(1)->attr('multiple'));
         $this->assertNull($select->eq(2)->attr('multiple'));
-        
+
         $options = pq('option',$select->eq(0));
         $this->assertEquals('', $options->eq(0)->text());
         $this->assertEquals('Blorg', $options->eq(1)->text());
@@ -49,51 +52,57 @@ class plugin_tagfilter_syntax_test extends DokuWikiTest {
         $this->assertEquals('1', $options->eq(1)->text());
         $this->assertEquals('2', $options->eq(2)->text());
     }
-    
+
     public function test_syntax_pagesearch() {
+        global $ID, $INFO;
+        $ID = 'test:plugin_tagfilter:start2';
+        $INFO = pageinfo(); //filepath is used
         $xhtml = p_wiki_xhtml('test:plugin_tagfilter:start2');
         $doc = phpQuery::newDocument($xhtml);
-    
+
         $form = pq('form[data-plugin=tagfilter]',$doc);
         $select = pq('select',$form);
-        $this->assertTrue($select->length() === 4);
+        $this->assertTrue($select->count() === 4);
 
-    
+
         $options = pq('option',$select->eq(0));
         $this->assertEquals('', $options->eq(0)->text());
         $this->assertEquals('Tagpage1', $options->eq(1)->text());
         $this->assertEquals('Tagpage2', $options->eq(2)->text());
     }
-    
+
     public function test_syntax_multi() {
+        global $ID, $INFO;
+        $ID = 'test:plugin_tagfilter:start3';
+        $INFO = pageinfo(); //filepath is used
         $xhtml = p_wiki_xhtml('test:plugin_tagfilter:start3');
         $doc = phpQuery::newDocument($xhtml);
-    
+
         $form = pq('form[data-plugin=tagfilter]',$doc);
-    
+
         $select = pq('select',$form);
-        $this->assertTrue($select->length() === 3);
+        $this->assertTrue($select->count() === 3);
         $this->assertEquals('multiple',$select->eq(0)->attr('multiple'));
         $this->assertEquals('multiple',$select->eq(1)->attr('multiple'));
         $this->assertEquals('multiple',$select->eq(2)->attr('multiple'));
-        
+
         $options = pq('option',$select->eq(0));
         $this->assertEquals('Blorg', $options->eq(0)->text());
 
     }
-    
+
     protected function _createPages() {
         saveWikiText('test:plugin_tagfilter:tags:tagpage1', '==== Tagpage1 ===='.DOKU_LF.'{{tag>cat1:blorg cat2:a cat3:1}}', 'test');
         saveWikiText('test:plugin_tagfilter:tags:tagpage2', '==== Tagpage2 ===='.DOKU_LF.'{{tag>cat1:blorg cat2:b cat3:2}}', 'test');
         saveWikiText('test:plugin_tagfilter:start', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*}}', 'test');
         saveWikiText('test:plugin_tagfilter:start2', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&pagesearch}}', 'test');
         saveWikiText('test:plugin_tagfilter:start3', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&multi}}', 'test');
-        
+
         idx_addPage('test:plugin_tagfilter:tags:tagpage1',false);
         idx_addPage('test:plugin_tagfilter:tags:tagpage2',false);
     }
-    
-    
-    
+
+
+
 
 }

--- a/_test/syntax.test.php
+++ b/_test/syntax.test.php
@@ -1,30 +1,35 @@
 <?php
+
 /**
  * @group plugin_tagfilter
  * @group plugins
  */
-class plugin_tagfilter_syntax_test extends DokuWikiTest {
+class plugin_tagfilter_syntax_test extends DokuWikiTest
+{
 
     protected $pluginsEnabled = [
-        'tag','tagfilter'
+        'tag', 'tagfilter'
     ];
-    public function setup() : void {
+
+    public function setup(): void
+    {
         parent::setup();
         $this->_createPages();
     }
 
 
-    public function test_basic_syntax() {
+    public function test_basic_syntax()
+    {
         global $ID, $INFO;
         $ID = 'test:plugin_tagfilter:start';
         $INFO = pageinfo(); //filepath is used
         $xhtml = p_wiki_xhtml('test:plugin_tagfilter:start');
         $doc = phpQuery::newDocument($xhtml);
 
-        $form = pq('form[data-plugin=tagfilter]',$doc);
+        $form = pq('form[data-plugin=tagfilter]', $doc);
 
         //echo $form;
-        $select = pq('select',$form);
+        $select = pq('select', $form);
         $this->assertTrue($select->count() === 3);
         $this->assertEquals('T1', $select->eq(0)->attr('name'));
         $this->assertEquals('T2', $select->eq(1)->attr('name'));
@@ -38,71 +43,72 @@ class plugin_tagfilter_syntax_test extends DokuWikiTest {
         $this->assertNull($select->eq(1)->attr('multiple'));
         $this->assertNull($select->eq(2)->attr('multiple'));
 
-        $options = pq('option',$select->eq(0));
+        $options = pq('option', $select->eq(0));
         $this->assertEquals('', $options->eq(0)->text());
         $this->assertEquals('Blorg', $options->eq(1)->text());
 
-        $options = pq('option',$select->eq(1));
+        $options = pq('option', $select->eq(1));
         $this->assertEquals('', $options->eq(0)->text());
         $this->assertEquals('A', $options->eq(1)->text());
         $this->assertEquals('B', $options->eq(2)->text());
 
-        $options = pq('option',$select->eq(2));
+        $options = pq('option', $select->eq(2));
         $this->assertEquals('', $options->eq(0)->text());
         $this->assertEquals('1', $options->eq(1)->text());
         $this->assertEquals('2', $options->eq(2)->text());
     }
 
-    public function test_syntax_pagesearch() {
+    public function test_syntax_pagesearch()
+    {
         global $ID, $INFO;
         $ID = 'test:plugin_tagfilter:start2';
         $INFO = pageinfo(); //filepath is used
         $xhtml = p_wiki_xhtml('test:plugin_tagfilter:start2');
         $doc = phpQuery::newDocument($xhtml);
 
-        $form = pq('form[data-plugin=tagfilter]',$doc);
-        $select = pq('select',$form);
+        $form = pq('form[data-plugin=tagfilter]', $doc);
+        $select = pq('select', $form);
         $this->assertTrue($select->count() === 4);
 
 
-        $options = pq('option',$select->eq(0));
+        $options = pq('option', $select->eq(0));
         $this->assertEquals('', $options->eq(0)->text());
         $this->assertEquals('Tagpage1', $options->eq(1)->text());
         $this->assertEquals('Tagpage2', $options->eq(2)->text());
     }
 
-    public function test_syntax_multi() {
+    public function test_syntax_multi()
+    {
         global $ID, $INFO;
         $ID = 'test:plugin_tagfilter:start3';
         $INFO = pageinfo(); //filepath is used
         $xhtml = p_wiki_xhtml('test:plugin_tagfilter:start3');
         $doc = phpQuery::newDocument($xhtml);
 
-        $form = pq('form[data-plugin=tagfilter]',$doc);
+        $form = pq('form[data-plugin=tagfilter]', $doc);
 
-        $select = pq('select',$form);
+        $select = pq('select', $form);
         $this->assertTrue($select->count() === 3);
-        $this->assertEquals('multiple',$select->eq(0)->attr('multiple'));
-        $this->assertEquals('multiple',$select->eq(1)->attr('multiple'));
-        $this->assertEquals('multiple',$select->eq(2)->attr('multiple'));
+        $this->assertEquals('multiple', $select->eq(0)->attr('multiple'));
+        $this->assertEquals('multiple', $select->eq(1)->attr('multiple'));
+        $this->assertEquals('multiple', $select->eq(2)->attr('multiple'));
 
-        $options = pq('option',$select->eq(0));
+        $options = pq('option', $select->eq(0));
         $this->assertEquals('Blorg', $options->eq(0)->text());
 
     }
 
-    protected function _createPages() {
-        saveWikiText('test:plugin_tagfilter:tags:tagpage1', '==== Tagpage1 ===='.DOKU_LF.'{{tag>cat1:blorg cat2:a cat3:1}}', 'test');
-        saveWikiText('test:plugin_tagfilter:tags:tagpage2', '==== Tagpage2 ===='.DOKU_LF.'{{tag>cat1:blorg cat2:b cat3:2}}', 'test');
+    protected function _createPages()
+    {
+        saveWikiText('test:plugin_tagfilter:tags:tagpage1', '==== Tagpage1 ====' . DOKU_LF . '{{tag>cat1:blorg cat2:a cat3:1}}', 'test');
+        saveWikiText('test:plugin_tagfilter:tags:tagpage2', '==== Tagpage2 ====' . DOKU_LF . '{{tag>cat1:blorg cat2:b cat3:2}}', 'test');
         saveWikiText('test:plugin_tagfilter:start', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*}}', 'test');
         saveWikiText('test:plugin_tagfilter:start2', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&pagesearch}}', 'test');
         saveWikiText('test:plugin_tagfilter:start3', '{{tagfilter>test:plugin_tagfilter:tags?T1=cat1:.*|T2=cat2:.*|T3=cat3:.*&multi}}', 'test');
 
-        idx_addPage('test:plugin_tagfilter:tags:tagpage1',false);
-        idx_addPage('test:plugin_tagfilter:tags:tagpage2',false);
+        idx_addPage('test:plugin_tagfilter:tags:tagpage1', false);
+        idx_addPage('test:plugin_tagfilter:tags:tagpage2', false);
     }
-
-
 
 
 }

--- a/action.php
+++ b/action.php
@@ -118,8 +118,8 @@ class action_plugin_tagfilter extends DokuWiki_Action_Plugin
         //partially copied from tag->helper with less checks and no meta lookups
         $page_names = [];
         foreach ($tag_list_r as $key => $tag_list) {
-            $tags_parsed = $Htag->_parseTagList($tag_list, true);
-            $pages_lookup = $Htag->_tagIndexLookup($tags_parsed);
+            $tags_parsed = $Htag->parseTagList($tag_list, true);
+            $pages_lookup = $Htag->getIndexedPagesMatchingTagQuery($tags_parsed);
             foreach ($pages_lookup as $page_lookup) {
                 // filter by namespace, root namespace is identified with a dot
                 // root namespace is specified, discard all pages who lay outside the root namespace

--- a/action.php
+++ b/action.php
@@ -8,198 +8,207 @@
  * @author  lisps
  */
 
-class action_plugin_tagfilter extends DokuWiki_Action_Plugin {
-	/**
-	 * Register the eventhandlers
-	 */
-	function register(Doku_Event_Handler $controller) {
-		$controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array ());
-		$controller->register_hook('DOKUWIKI_STARTED', 'AFTER',  $this, '_addparams');
-		$controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE',  $this, '_ajax_call');
-	}
+class action_plugin_tagfilter extends DokuWiki_Action_Plugin
+{
+    /**
+     * Register the eventhandlers
+     */
+    public function register(Doku_Event_Handler $controller)
+    {
+        $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array());
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, '_addparams');
+        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, '_ajax_call');
+    }
 
-	function _addparams($event, $param) {
-		global $JSINFO;
-		global $INPUT;
-	    // filter for ft* in GET
-	    $f = function($value) {
-            return strpos($value,"tf") === 0;
+    public function _addparams($event, $param)
+    {
+        global $JSINFO;
+        global $INPUT;
+        // filter for ft* in GET
+        $f = function ($value) {
+            return strpos($value, "tf") === 0;
         };
-	    $get_tagfilter = array_filter(array_keys($_GET),$f);
+        $get_tagfilter = array_filter(array_keys($_GET), $f);
 
-		//filter for ft<key>_<label> and add it to JSINFO to select it via JavaScript
-		foreach($get_tagfilter as $param){
-			$ret = preg_match('/^tf(\d+)\_([\w\:äöü\-\/#]+)/',$param,$matches);
+        //filter for ft<key>_<label> and add it to JSINFO to select it via JavaScript
+        foreach ($get_tagfilter as $param) {
+            $ret = preg_match('/^tf(\d+)\_([\w\:äöü\-\/#]+)/', $param, $matches);
 
-			if($ret && is_numeric($matches[1]) && $matches[2]) {
+            if ($ret && is_numeric($matches[1]) && $matches[2]) {
                 $JSINFO['tagfilter'][] = [
                     'key' => $matches[1],
                     'label' => $matches[2],
                     'values' => $INPUT->str($param) ? [$INPUT->str($param)] : $INPUT->arr($param)
                 ];
             }
-		}
+        }
 
-	}
+    }
 
-	/**
-	 * Inserts the toolbar button
-	 */
-	function insert_button($event, $param) {
-		$event->data[] = [
-			'type'   => 'format',
-			'title' => 'Tagfilter plugin',
-			'icon'   => '../../plugins/tagfilter/tagfilter.png',
-			'sample' => '<namespace>? <Label>=<TagAusdruck>=<Tags Selected>|... &<pagelistoptions (&multi&nouser&chosen)>',
-			'open' => '{{tagfilter>',
-			'close'=>'}}',
-			'insert'=>'',
+    /**
+     * Inserts the toolbar button
+     */
+    public function insert_button($event, $param)
+    {
+        $event->data[] = [
+            'type' => 'format',
+            'title' => 'Tagfilter plugin',
+            'icon' => '../../plugins/tagfilter/tagfilter.png',
+            'sample' => '<namespace>? <Label>=<TagAusdruck>=<Tags Selected>|... &<pagelistoptions (&multi&nouser&chosen)>',
+            'open' => '{{tagfilter>',
+            'close' => '}}',
+            'insert' => '',
         ];
-	}
+    }
 
-	/**
-	 * ajax Request Handler
-	 */
-	function _ajax_call($event, $param) {
-		if ($event->data !== 'plugin_tagfilter') {
-			return;
-		}
-		//no other ajax call handlers needed
-		$event->stopPropagation();
-		$event->preventDefault();
+    /**
+     * ajax Request Handler
+     */
+    public function _ajax_call($event, $param)
+    {
+        if ($event->data !== 'plugin_tagfilter') {
+            return;
+        }
+        //no other ajax call handlers needed
+        $event->stopPropagation();
+        $event->preventDefault();
 
-		global $INPUT;
-		global $lang;
+        global $INPUT;
+        global $lang;
 
-		//Variables
-		$tagfilterFormId = $INPUT->int('id');
-		$form = $this->getJSONdecodedUrlParameter('form');
-		$ns = $this->getJSONdecodedUrlParameter('ns');
-		$flags = (array)$this->getJSONdecodedUrlParameter('flags');
-		//print_r($flags);
-		$tagfilterFlags = isset($flags[1]) ? (array)$flags[1] : [];  //TODO parse?
-		$pagelistFlags = isset($flags[0]) ? (array)$flags[0] : [];
-		//print_r($tagfilterFlags);
-		$pagesearch = $this->getJSONdecodedUrlParameter('pagesearch');
+        //Variables
+        $tagfilterFormId = $INPUT->int('id');
+        $form = $this->getJSONdecodedUrlParameter('form');
+        $ns = $this->getJSONdecodedUrlParameter('ns');
+        $flags = (array)$this->getJSONdecodedUrlParameter('flags');
+        //print_r($flags);
+        $tagfilterFlags = isset($flags[1]) ? (array)$flags[1] : [];  //TODO parse?
+        $pagelistFlags = isset($flags[0]) ? (array)$flags[0] : [];
+        //print_r($tagfilterFlags);
+        $pagesearch = $this->getJSONdecodedUrlParameter('pagesearch');
 
-		//load tagfilter plugin
+        //load tagfilter plugin
         /** @var helper_plugin_tagfilter $Htagfilter */
-		$Htagfilter = $this->loadHelper('tagfilter', false);
+        $Htagfilter = $this->loadHelper('tagfilter', false);
 
-		//load tag plugin
+        //load tag plugin
         /** @var helper_plugin_tag $Htag */
-		if (is_null($Htag = $this->loadHelper('tag', false))) {
-			$this->sendResponse(sprintf($Htagfilter->getLang('missing_plugin'),'tag'));
-			return;
-		}
-		//load tag plugin
+        if (is_null($Htag = $this->loadHelper('tag', false))) {
+            $this->sendResponse(sprintf($Htagfilter->getLang('missing_plugin'), 'tag'));
+            return;
+        }
+        //load tag plugin
         /** @var helper_plugin_pagelist $Hpagelist */
-		if (is_null($Hpagelist = $this->loadHelper('pagelist', false))) {
-			$this->sendResponse(sprintf($Htagfilter->getLang('missing_plugin'),'pagelist'));
-			return;
-		}
+        if (is_null($Hpagelist = $this->loadHelper('pagelist', false))) {
+            $this->sendResponse(sprintf($Htagfilter->getLang('missing_plugin'), 'pagelist'));
+            return;
+        }
 
-		$form = array_filter($form);//remove empty entries
+        $form = array_filter($form);//remove empty entries
 
-		$tag_list_r = array();
+        $tag_list_r = [];
 
-		foreach($form as $item){ //rearrange entries for tag plugin lookup
-			$tag_list_r[]=  implode(' ',array_filter($item));
-		}
+        foreach ($form as $item) { //rearrange entries for tag plugin lookup
+            $tag_list_r[] = implode(' ', array_filter($item));
+        }
 
-		$tag_list_r = array_filter($tag_list_r);
+        $tag_list_r = array_filter($tag_list_r);
 
-		//lookup the pages from the taglist
-		//partially copied from tag->helper with less checks and no meta lookups
-		$page_names = array();
-		foreach($tag_list_r as $key=>$tag_list){
-			$tags_parsed = $Htag->_parseTagList($tag_list, true);
-			$pages_lookup = $Htag->_tagIndexLookup($tags_parsed);
-			foreach($pages_lookup as  $page_lookup){
-				// filter by namespace, root namespace is identified with a dot // root namespace is specified, discard all pages who lay outside the root namespace
-				if(($ns == '.' && getNS($page_lookup) === false) || ($ns && strpos(':'.getNS($page_lookup).':', ':'.$ns.':') === 0) || $ns === '') {
-					if (auth_quickaclcheck($page_lookup) >= AUTH_READ) {
+        //lookup the pages from the taglist
+        //partially copied from tag->helper with less checks and no meta lookups
+        $page_names = [];
+        foreach ($tag_list_r as $key => $tag_list) {
+            $tags_parsed = $Htag->_parseTagList($tag_list, true);
+            $pages_lookup = $Htag->_tagIndexLookup($tags_parsed);
+            foreach ($pages_lookup as $page_lookup) {
+                // filter by namespace, root namespace is identified with a dot
+                // root namespace is specified, discard all pages who lay outside the root namespace
+                if (($ns == '.' && getNS($page_lookup) === false)
+                    || ($ns && strpos(':' . getNS($page_lookup) . ':', ':' . $ns . ':') === 0)
+                    || $ns === '') {
+                    if (auth_quickaclcheck($page_lookup) >= AUTH_READ) {
                         $page_names[$key][] = $page_lookup;
                     }
-				}
-			}
-		}
+                }
+            }
+        }
 
 
+        //get the first item
+        if (!is_array($pages_intersect = array_shift($page_names))) {
+            $pages_intersect = [];
+        }
 
-		//get the first item
-		if(!is_array($pages_intersect = array_shift($page_names))) {
-			$pages_intersect = array();
-		}
+        //find the intersections
+        foreach ($page_names as $names) {
+            $pages_intersect = array_intersect($pages_intersect, $names);
+        }
 
-		//find the intersections
-		foreach($page_names as $names){
-			$pages_intersect = array_intersect($pages_intersect,$names);
-		}
+        //intersections with the pagesearch
+        if (is_array($pagesearch) && !empty($pagesearch)) {
+            $pages_intersect = array_intersect($pages_intersect, $pagesearch);
+        }
 
-		//intersections with the pagesearch
-		if(is_array($pagesearch) && !empty($pagesearch)){
-			$pages_intersect = array_intersect($pages_intersect,$pagesearch);
-		}
+        //no matching pages
+        if (count($pages_intersect) === 0) {
+            $this->sendResponse('<i>' . $lang['nothingfound'] . '</i>');
+            return;
+        }
 
-		//no matching pages
-		if(count($pages_intersect)===0){
-			$this->sendResponse('<i>'.$lang['nothingfound'].'</i>');
-			return;
-		}
+        $pages_intersect = array_filter($pages_intersect, [$this, 'filterHide_Template']);
 
-		$pages_intersect = array_filter($pages_intersect, [$this, 'filterHide_Template']);
-
-		$pages = [];
-		foreach($pages_intersect as $page){
-			$title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
-			$pages[$title?:$page] = [
-					'title' => $title?:$page,
-					'id' => $page
+        $pages = [];
+        foreach ($pages_intersect as $page) {
+            $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
+            $pages[$title ?: $page] = [
+                'title' => $title ?: $page,
+                'id' => $page
             ];
-		}
-		if(is_array($pagelistFlags) && in_array('rsort',$pagelistFlags)) {
-			krsort($pages,SORT_STRING|SORT_FLAG_CASE);
-		} else {
-			ksort($pages,SORT_STRING|SORT_FLAG_CASE);
-		}
+        }
+        if (is_array($pagelistFlags) && in_array('rsort', $pagelistFlags)) {
+            krsort($pages, SORT_STRING | SORT_FLAG_CASE);
+        } else {
+            ksort($pages, SORT_STRING | SORT_FLAG_CASE);
+        }
 
-		if(!isset($tagfilterFlags['tagcolumn'])){
+        if (!isset($tagfilterFlags['tagcolumn'])) {
             $tagfilterFlags['tagcolumn'] = [];
         }
-		foreach($tagfilterFlags['tagcolumn'] as $tagcolumn) {
-			$Hpagelist->addColumn('tagfilter',hsc($tagcolumn));
-		}
-		$Hpagelist->setFlags($pagelistFlags);
-		$Hpagelist->startList();
+        foreach ($tagfilterFlags['tagcolumn'] as $tagcolumn) {
+            $Hpagelist->addColumn('tagfilter', hsc($tagcolumn));
+        }
+        $Hpagelist->setFlags($pagelistFlags);
+        $Hpagelist->startList();
 
-		foreach ($pages as $page) {
-			$Hpagelist->addPage($page);
-		}
-		$text = $Hpagelist->finishList();
+        foreach ($pages as $page) {
+            $Hpagelist->addPage($page);
+        }
+        $text = $Hpagelist->finishList();
 
-		$this->sendResponse($text);
-	}
+        $this->sendResponse($text);
+    }
 
-	private function getJSONdecodedUrlParameter($name) {
-		global $INPUT;
+    private function getJSONdecodedUrlParameter($name)
+    {
+        global $INPUT;
 
-		$param = null;
-		if($INPUT->has($name)) {
-			$param = $INPUT->param($name);
-			$param = json_decode($param);
-		}
-		return $param;
-	}
+        $param = null;
+        if ($INPUT->has($name)) {
+            $param = $INPUT->param($name);
+            $param = json_decode($param);
+        }
+        return $param;
+    }
 
     /**
      * @param string $text
      */
-	private function sendResponse($text) {
-		global $INPUT;
-		$tagfilter_id = $INPUT->int('id');
-		echo json_encode(['id'=>$tagfilter_id,'text'=>$text]);
-	}
+    private function sendResponse($text)
+    {
+        global $INPUT;
+        $tagfilter_id = $INPUT->int('id');
+        echo json_encode(['id' => $tagfilter_id, 'text' => $text]);
+    }
 
     /**
      * Filter function
@@ -208,10 +217,10 @@ class action_plugin_tagfilter extends DokuWiki_Action_Plugin {
      * @param string $val
      * @return bool
      */
-	private function filterHide_Template($val) {
-		return strpos($val,"_template")===false && @file_exists(wikiFN($val));
-	}
-
+    private function filterHide_Template($val)
+    {
+        return strpos($val, "_template") === false && @file_exists(wikiFN($val));
+    }
 
 }
 

--- a/helper.php
+++ b/helper.php
@@ -1,502 +1,565 @@
 <?php
+
+use dokuwiki\Utf8\PhpString;
+
 /**
- * DokuWiki Plugin tagfilter (Helper Component) 
+ * DokuWiki Plugin tagfilter (Helper Component)
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  lisps
  */
+class helper_plugin_tagfilter extends DokuWiki_Plugin
+{
+    /**
+     *
+     * @var helper_plugin_tag
+     */
+    protected $Htag;
 
-class helper_plugin_tagfilter extends DokuWiki_Plugin {
-	/**
-	 * 
-	 * @var helper_plugin_tag
-	 */
-	protected $Htag;
-	/**
-	* Constructor gets default preferences and language strings
-	*/
-	function __construct() {
-		if (plugin_isdisabled('tag') || (!$this->Htag = plugin_load('helper', 'tag'))) {
-			msg('tag plugin is missing', -1);
-			return false;
-		}
-	}
-	
-	function getMethods() {
-		$result = array();
-		$result[] = array(
-	                'name'   => 'getTagsByRegExp',
-	                'desc'   => 'returns tags for given Regular Expression',
-					'params' => array(
-			                    'tags (required)' => 'string',
-			                    'namespace (optional)' => 'string',),
-	                'return' => array('tags' => 'array'),
-		);
-		$result[] = array(
-	                'name'   => 'getTagsByNamespace',
-	                'desc'   => 'returns tags for given namespace',
-					'params' => array(
-			                    'namespace' => 'string',),
-	                'return' => array('tags' => 'array'),
-		);
-		$result[] = array(
-	                'name'   => 'getTagsBySiteID',
-	                'desc'   => 'returns tags for given siteID',
-					'params' => array(
-			                    'siteID' => 'string',),
-	                'return' => array('tags' => 'array'),
-		);
+    /**
+     * Constructor gets default preferences and language strings
+     */
+    public function __construct()
+    {
+        $this->Htag = $this->loadHelper('tag');
+    }
 
-		return $result;
-	}
-	function isNewTagVersion(){
+    public function getMethods()
+    {
+        $result = [];
+        $result[] = [
+            'name' => 'getTagsByRegExp',
+            'desc' => 'returns tags for given Regular Expression',
+            'params' => [
+                'tags (required)' => 'string',
+                'namespace (optional)' => 'string',],
+            'return' => ['tags' => 'array'],
+        ];
+        $result[] = [
+            'name' => 'getTagsByNamespace',
+            'desc' => 'returns tags for given namespace',
+            'params' => [
+                'namespace' => 'string',],
+            'return' => ['tags' => 'array'],
+        ];
+        $result[] = [
+            'name' => 'getTagsByPageID',
+            'desc' => 'returns tags for given pageID',
+            'params' => [
+                'pageID' => 'string',],
+            'return' => ['tags' => 'array'],
+        ];
 
-		$Htag  =$this->Htag;
-		if(!$Htag)return false;
-		$info =$Htag->getInfo();
-		return (strtotime($info['date'])>strtotime('2012-08-01'))?true:false;
-	}
-	
-	//sucht im Tagindex nach Tags mittels preg Ausdrucken
-	function getTagsByRegExp($tags, $ns = ''){
-		
-		$Htag  =$this->Htag;
-		if(!$Htag)return false;
-		$info=$Htag->getInfo();
-		if($this->isNewTagVersion())
-			return $this->getTagsByRegExp_New($tags, $ns,false);
-		$fullTags = array(); //gefundene Tags
-		 
-		$tags = $Htag->_parseTagList($tags, true);
-		$alltags = $this->getTagsByNamespace($ns,false);
-		foreach($tags  as  $tag){
-			foreach($alltags as $alltag){
-				if($this->preg_matchTag($tag, $alltag)){
-					$fullTags[$alltag] = $this->getTagLabel($alltag);
-				}
-			}
-		}
-		$fullTags = array_unique($fullTags);
-		asort($fullTags);
-		
-		return  $fullTags;
-	}
-	
-	
-	public function preg_matchTag($pregmatch,$tag) {
-		return @preg_match('/^'.$pregmatch.'$/i',$tag);
-	}
-	public function getTagLabel($tag) {
-		$label = strrchr($tag,':');
-		$label = $label !=''?$label:$tag;
-		return mb_convert_case(str_replace('_',' ',trim($label,':')), MB_CASE_TITLE, "UTF-8");
-	}
+        return $result;
+    }
 
-	
-	protected $_tagsByNamespace = array();
-	function getTagsByNamespace($ns = '',$acl_safe = true){
-		if(!isset($this->_tagsByNamespace[$ns])) {
-			$Htag  =$this->Htag;
-			if(!$Htag)return false;
-		
-			if($this->isNewTagVersion())
-				return array_keys($this->getTagsByRegExp_New('.*',$ns,$acl_safe));
-			
-			$index = array_filter($Htag->topic_idx);
+    /**
+     * Search in Tagindex for tags that matches the tag pattern and are in requested namespace
+     *
+     * @param string $tagExpression regexp pattern of wanted tags e.g. "status:.*"
+     * @param string $ns list only pages from this namespace
+     * @param bool $aclSafe if true, add only tags that are on readable pages
+     * @return string[]|false with tag=>label pairs
+     *
+     */
+    public function getTagsByRegExp($tagExpression, $ns = '', $aclSafe = false)
+    {
+        $Htag = $this->Htag;
+        if (!$Htag) {
+            return false;
+        }
 
-			$tags=array();
-			if($ns === ''){
-				if($acl_safe) {
-					foreach($index as $tag=>$page_r){
-						foreach($page_r as $page) {
-							$perm = auth_quickaclcheck($page);
-							if (!$perm < AUTH_READ){
-								$tags[]=$tag;
-								break;
-							}
-						}
-					}
-				} else {
-					$tags = array_keys($index);
-				}
-			} else {
-				foreach ($index as $tag=>$page_r){
-					if($this->_checkPageArrayInNamespace($page_r,$ns)){
-						$tags[]=$tag;
-					}
-				}
+        $tags = $this->getIndex('subject', '_w');
 
-			}
-			$this->_tagsByNamespace[$ns]=array_unique($tags);
-		}
-		return $this->_tagsByNamespace[$ns];
-	}
-	
-	function _checkPageArrayInNamespace($page_r,$ns,$acl_safe = true){
-		$Htag  =$this->Htag;
-		if(!$Htag)return false;
-		foreach($page_r as $page){
-			if(noNS($page) ==='_template') return false;
-			if ($ns && (strpos(':'.getNS($page).':', ':'.$ns.':') === 0)){
-				if (!$acl_safe) return true;
-				$perm = auth_quickaclcheck($page);
-				if (!$perm < AUTH_READ) {
-					if(!page_exists($page)) $Htag->_updateTagIndex($page,array());
-					return true;
-				}
+        $matchedTag_label = [];
+        foreach ($tags as $tag) {
+            if ($this->matchesTagExpression($tagExpression, $tag) && $this->isTagInNamespace($tag, $ns, $aclSafe)) {
+                $matchedTag_label[$tag] = $this->getTagLabel($tag);
+            }
+        }
+        asort($matchedTag_label);  //TODO update next release to dokuwiki builtin sort
+        return $matchedTag_label;
+    }
 
-			}
-			//if($Htag->_isVisible($page,$ns))
-			//	return true;
-			
-		}
-		return false;
-	}
-	
-	function canRead($pageid) {
-		$Htag  =$this->Htag;
-		$perm = auth_quickaclcheck($pageid);
-		if (!($perm < AUTH_READ)) {
-			if(!page_exists($pageid) && !$this->isNewTagVersion()) $Htag->_updateTagIndex($pageid,array());
-			return true;
-		}
-		return false;
-	}
-	
-	function _checkPageArrayInNamespace_New($page_r,$ns,$acl_safe = true){
-		$Htag  =$this->Htag;
-		if(!$Htag)return false;
-		foreach($page_r as $page){
-			if($Htag->_isVisible($page,$ns)) {
-				if (!$acl_safe) return true;
-				$perm = auth_quickaclcheck($page);
-				if (!$perm < AUTH_READ)
-					return true;
-			
-			}
 
-		}
-		return false;
-	}
-	
-	/*
-	 * liefert alle Tags f�r eine bestimmte seite Zur�ck
-	 */
-	function getTagsBySiteID($siteID){
-		if($this->isNewTagVersion())
-			return $this->getTagsBySiteId_New($siteID);
-		
-		$Htag  =$this->Htag;
-		if(!$Htag)return false;
-		
-		$index = array_filter($Htag->topic_idx);
-		/*echo '<pre>';
-		print_r($index);
-		echo '</pre>';*/
-		$tags=array();
-		foreach ($index as $tag=>$page_r){
-			if(in_array($siteID,$page_r)){
-				$tags[]=$tag;
-			}
-		}
-		$tags=array_unique($tags);
-		return $tags;
-	}
-	
-	function getTagsBySiteId_New($siteID){
-		$meta = p_get_metadata($siteID,'subject');
-		if($meta === NULL) $meta=array();
-		return $meta;
-	}
-	
-	function _tagCompare ($tag1,$tag2){
-		return $tag1==$tag2;
-	}
-	function getTagsByRegExp_New($tag_expr,$ns = '',$acl_safe=true){
-		$tags = $this->getIndex('subject','_w');
-		$tag_label_r = array();
-		foreach($tags  as  $tag){
-			if(@preg_match('/^'.$tag_expr.'$/i',$tag) && $this->_checkTagInNamespace($tag,$ns,$acl_safe)){
-				//$label =stristr($tag,':');
-				$label = strrchr($tag,':');
-				$label = $label !=''?$label:$tag;
-				$tag_label_r[$tag] = ucwords(trim(str_replace('_',' ',trim($label,':'))));
-			}
-		}
-		asort($tag_label_r);
-		return $tag_label_r;
-	}
-	function _checkTagInNamespace($tag,$ns,$acl_safe=true){
-		if($ns == '') return true;
-		$indexer = idx_get_indexer();
-		$pages = $indexer->lookupKey('subject', $tag, array($this, '_tagCompare'));
-		return $this->_checkPageArrayInNamespace_New($pages,$ns,$acl_safe);
-	}
-	
-	/*
-	 * from inc/indexer.php 
-	 */
-	public function getIndex($idx, $suffix) {
+    /**
+     * Test if tag matches with requested pattern
+     *
+     * @param string $tagExpression regexp pattern of wanted tags e.g. "status:.*"
+     * @param string $tag
+     * @return bool
+     */
+    public function matchesTagExpression($tagExpression, $tag)
+    {
+        return (bool) @preg_match('/^'.$tagExpression.'$/i', $tag);
+    }
+
+    /**
+     * Returns latest part of tag as label
+     *
+     * @param string $tag
+     * @return string
+     */
+    public function getTagLabel($tag)
+    {
+        $label = strrchr($tag, ':');
+        $label = $label != '' ? $label : $tag;
+        return PhpString::ucwords(str_replace('_', ' ', trim($label, ':')));
+    }
+
+
+    /**
+     * Returns all tags used in given namespace
+     *
+     * @param string $ns list only tags used on pages from this namespace
+     * @param bool $aclSafe if true, checks if user has read permission for the pages containing the tags
+     * @return array|false|int[]|string[]
+     */
+    public function getTagsByNamespace($ns = '', $aclSafe = true)
+    {
+        if (!$this->Htag) {
+            return false;
+        }
+
+        return array_keys($this->getTagsByRegExp('.*', $ns, $aclSafe));
+    }
+
+    /**
+     * Checks if current user can read the given pageid
+     *
+     * @param string $pageid
+     * @return bool
+     */
+    public function canRead($pageid)
+    {
+        return auth_quickaclcheck($pageid) >= AUTH_READ;
+    }
+
+    /**
+     * Returns all tags for the given pageid
+     *
+     * @param string $pageID
+     * @return array|mixed
+     */
+    public function getTagsByPageID($pageID)
+    {
+        $meta = p_get_metadata($pageID, 'subject');
+        if ($meta === null) {
+            $meta = [];
+        }
+        return $meta;
+    }
+
+    /**
+     * Returns true if tags are equal
+     *
+     * @param string $tag1
+     * @param string $tag2
+     * @return bool whether equal tags
+     */
+    public function tagCompare($tag1, $tag2)
+    {
+        return $tag1 == $tag2;
+    }
+
+
+    /**
+     * Checks if tag is used in the namespace, eventually can consider read permission as well
+     *
+     * @param string $tag
+     * @param string $ns list pages from this namespace
+     * @param bool $aclSafe if true, uses tag from a page only if user has read permissions
+     * @return bool
+     */
+    protected function isTagInNamespace($tag, $ns, $aclSafe = true)
+    {
+        if ($ns == '') {
+            return true;
+        }
+        $Htag = $this->Htag;
+        if (!$Htag) {
+            return false;
+        }
+
+        $indexer = idx_get_indexer();
+        $pages = $indexer->lookupKey('subject', $tag, [$this, 'tagCompare']);
+
+        foreach ($pages as $page) {
+            if ($Htag->_isVisible($page, $ns)) {
+                if (!$aclSafe) {
+                    return true;
+                }
+                if (auth_quickaclcheck($page) >= AUTH_READ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns entire index file as array
+     *
+     * from inc/indexer.php
+     *
+     * @param string $idx
+     * @param string $suffix
+     * @return array|false
+     */
+    protected function getIndex($idx, $suffix)
+    {
         global $conf;
-        $fn = $conf['indexdir'].'/'.$idx.$suffix.'.idx';
-        if (!@file_exists($fn)) return array();
+        $fn = $conf['indexdir'] . '/' . $idx . $suffix . '.idx';
+        if (!@file_exists($fn)) {
+            return [];
+        }
         return file($fn, FILE_IGNORE_NEW_LINES);
     }
-	
-	protected $ps_ns = '';
-	protected $ps_pages_id = array();
-	protected $ps_pages = array();
-	
-	function getPagesByTag($tag,$ns=''){
-		$tags = explode(' ',$tag);
-		$this->startPageSearch($ns);
-		foreach($tags as $t){
-			if($t[0] == '+') $this->addAndTag(substr($t,1));
-			elseif($t[0] == '-') $this->addSubTag(substr($t,1));
-			else $this->addOrTag($t);
-		}
-		return $this->getPages();
-	}
-	
-	function startPageSearch($ns = '') {
-		$this->ps_ns = $ns;
-		$this->ps_pages_id = array();
-		$this->ps_pages = array();
-	}
-	
-	function addAndTag($tag){
-		$tags = $this->getTagsByRegExp($tag,$this->ps_ns);
-		$pages = array();
-		foreach($tags as $t=>$v){ 
-			$Hpages =$this->Htag->getTopic($this->ps_ns,null,$t);
-			foreach($Hpages as $p){
-				$pages[] = $p['id'];
-				if(!isset($this->ps_pages[$p['id']])) $this->ps_pages[$p['id']] = $p;
-			}
-			
-		}
-		$pages = array_unique($pages);
-		$this->ps_pages_id = array_intersect($this->ps_pages_id,$pages);
-	}
-	
-	function addSubTag($tag){
-		$tags = $this->getTagsByRegExp($tag,$this->ps_ns);
-		$pages = array();
-		foreach($tags as $t=>$v){ 
-			$Hpages =$this->Htag->getTopic($this->ps_ns,'',$t);
-			foreach($Hpages as $p){
-				$pages[] = $p['id'];
-			}
-		}
-		$pages = array_unique($pages);
-		$this->ps_pages_id = array_diff($this->ps_pages_id,$pages);
-	}
-	function addOrTag($tag){
-		$tags = $this->getTagsByRegExp($tag,$this->ps_ns);
-		$pages = array();
-		foreach($tags as $t=>$v){ 
-			$Hpages =$this->Htag->getTopic($this->ps_ns,'',$t);
-			foreach($Hpages as $p){
-				$pages[] = $p['id'];
-				if(!isset($this->ps_pages[$p['id']])) $this->ps_pages[$p['id']] = $p;
-			}
-		}
-		$pages = array_unique($pages);
-		$this->ps_pages_id = array_merge($this->ps_pages_id,$pages);
-		$this->ps_pages_id = array_unique($this->ps_pages_id);
-		
-		//print_r($this->ps_pages_id);
-	}
-	function getPages(){
-		$ret = array();
-		foreach ($this->ps_pages_id as $id){
-			$ret[] = $this->ps_pages[$id];
-		}
-		return $ret;
-	}
-	
-	function getImageLinkByTag($tag){
-		$id = $this->getConf('nsTagImage').':'.str_replace(array(' ',':'),'_',$tag);
-		$src = $id .'.jpg';
-		if(!@file_exists(mediaFN($src))) {
-			$src = $id .'.png';
-			if(!@file_exists(mediaFN($src))) {
-				$src = $id .'.jpeg';
-				if(!@file_exists(mediaFN($src))) {
-					$src = false;
-				}
-			}
-		}
-		if($src != false) {
-			return ml($src);
-		}
-		return false;
-	}
-	
-	function getTagImageColumn($id,$col,$ns){
-		if(!isset($this->_pageTags[$id])) {
-			$this->_pageTags[$id] = $this->getTagsBySiteID($id);
-		}
-		$foundTags = array();
-		foreach($this->_pageTags[$id] as $tag) {
-			if($this->preg_matchTag($col, $tag)) {
-				$foundTags[] = hsc($this->getTagLabel($tag));
-			}
-		}
-		$images = array();
-		foreach($foundTags as $foundTag) {
-			$imageid = $ns.':'.substr($foundTag,strrpos($foundTag,':'));
 
-			$src = $imageid .'.jpg';
-			if(!@file_exists(mediaFN($src))) {
-				$src = $imageid .'.png';
-				if(!@file_exists(mediaFN($src))) {
-					$src = $imageid .'.jpeg';
-					if(!@file_exists(mediaFN($src))) {
-						$src = $imageid .'.gif';
-						if(!@file_exists(mediaFN($src))) {
-							$src = false;
-						}
-					}
-				}
-			}
-			if($src != false) {
-				$images[] = '<img src="'.ml($src).' " class="media" style="height:max-width:200px;"/>';
-			}
-		}
+    /** @var string  */
+    protected $ps_ns = '';
+    /** @var array  */
+    protected $ps_pages_id = [];
+    /** @var array  */
+    protected $ps_pages = [];
 
-		return implode("<br>",$images);
+    /**
+     * @param string $tag space separated tags
+     * @param string $ns list only pages from this namespace
+     * @return array
+     */
+    public function getPagesByTag($tag, $ns = '')
+    {
+        $tags = explode(' ', $tag);
+        $this->startPageSearch($ns);
+        foreach ($tags as $t) {
+            if ($t[0] == '+') {
+                $this->addAndTag(substr($t, 1));
+            } elseif ($t[0] == '-') {
+                $this->addSubTag(substr($t, 1));
+            } else {
+                $this->addOrTag($t);
+            }
+        }
+        return $this->getPages();
+    }
 
-	}
-	
-	/*
-	 * return all pages defined by tag_list_r in a specific namespace
-	 * 
-	 * @param ns string the namespace to look in
-	 * @param tag_list_r array an array containing strings with tags seperated by ' '
-	 *
-	 */
-	function getAllPages($ns,$tag_list_r){
-		$pages = array();
-		$pages[''] = '';
-		
-		$tag_list = implode(' ',$tag_list_r);
+    /**
+     * @param string $ns
+     */
+    protected function startPageSearch($ns = '')
+    {
+        $this->ps_ns = $ns;
+        $this->ps_pages_id = [];
+        $this->ps_pages = [];
+    }
 
-		$page_r = $this->getPagesByTags($ns,$tag_list);
+    /**
+     * @param string $tagExpression regexp pattern of wanted tags e.g. "status:.*"
+     */
+    protected function addAndTag($tagExpression)
+    {
+        $tags = $this->getTagsByRegExp($tagExpression, $this->ps_ns);
+        $pages = [];
+        foreach ($tags as $t => $v) {
+            $Hpages = $this->Htag->getTopic($this->ps_ns, null, $t);
+            foreach ($Hpages as $p) {
+                $pages[] = $p['id'];
+                if (!isset($this->ps_pages[$p['id']])) {
+                    $this->ps_pages[$p['id']] = $p;
+                }
+            }
 
-		foreach($page_r as $page){
-			$title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
-			$title = $title?$title:$page;
-			$pages[$page]=strip_tags($title);  //FIXME hsc() doesent work with chosen
-		}
+        }
+        $pages = array_unique($pages);
+        $this->ps_pages_id = array_intersect($this->ps_pages_id, $pages);
+    }
 
-		asort($pages);
-		return $pages;
-	}
-	
-	function getPageTitle($pageid) {
-		$title = p_get_metadata($pageid, 'title', METADATA_DONT_RENDER);
-		$title = $title?$title:$pageid;
-		return strip_tags($title);  
-	}
-	
-	/*
-	 * gets the pages defined by tag_list
-	 *
-	 * partially copied from tag->helper with less checks (on cache) and no meta lookups
-	 * @param ns string the namespace to look in
-	 * @param tag_list string the tags seperated by ' '
-	 *
-	 * @return array array of page ids
-	 */
-	function getPagesByTags($ns,$tag_list) {
-		$page_names = array();
-		$tags_parsed = $this->Htag->_parseTagList($tag_list, true);
-		$pages_lookup = $this->Htag->_tagIndexLookup($tags_parsed);
-		foreach($pages_lookup as  $page_lookup){
-			// filter by namespace, root namespace is identified with a dot // root namespace is specified, discard all pages who lay outside the root namespace
-			if((($ns == '.') && (getNS($page_lookup) == false)) || ( (strpos(':'.getNS($page_lookup).':', ':'.$ns.':') === 0)) || $ns === '') {
-				$perm = auth_quickaclcheck($page_lookup);
-				if (!($perm < AUTH_READ))
-					$page_names[] = $page_lookup;
-			}
-		}
-		return $page_names;		
-	}
-	function getTagCategory($tag){
-		$label = strstr($tag,':',true);
-		$label = $label !=''?$label:$tag;
-		return ucwords(str_replace('_',' ',trim($label,':')));
-	}
-	function th($tag = '') {
-		if(strpos($tag,'*'))
-			return $this->getTagCategory($tag);
-		else 
-			return $this->getTagLabel($tag);
-	}
-	
-	public $_pageTags = array();
-	function td($id,$col){
-		if(!isset($this->_pageTags[$id])) {
-			$this->_pageTags[$id] = $this->getTagsBySiteID($id);
-		}
-		$foundTags = array();
-		foreach($this->_pageTags[$id] as $tag) {
-			if($this->preg_matchTag($col, $tag)) {
-				$foundTags[] = hsc($this->getTagLabel($tag));
-			}	
-		}
-		return implode("<br>",$foundTags);
-	}
-	
-	
-	
-	/**
-	 * 
-	 * 
-	 * @param string $tags
-	 * @param string $ns
-	 * @return array [tag]=>[]pages
-	 */
-	function getRelationsByTagRegExp($tags, $ns = ''){
-		$relations = array();
-		
-		$Htag  =$this->Htag;
-		if(!$Htag)return false;
+    /**
+     * @param string $tagExpression regexp pattern of wanted tags e.g. "status:.*"
+     */
+    protected function addSubTag($tagExpression)
+    {
+        $tags = $this->getTagsByRegExp($tagExpression, $this->ps_ns);
+        $pages = array();
+        foreach ($tags as $t => $v) {
+            $Hpages = $this->Htag->getTopic($this->ps_ns, '', $t);
+            foreach ($Hpages as $p) {
+                $pages[] = $p['id'];
+            }
+        }
+        $pages = array_unique($pages);
+        $this->ps_pages_id = array_diff($this->ps_pages_id, $pages);
+    }
 
-		$tags = $Htag->_parseTagList($tags, false); //array
-		
-		if($this->isNewTagVersion()) {
-		    $indexer = idx_get_indexer();
-		    $indexTags = array_keys($indexer->histogram(1, 0, 3, 'subject'));
-		} else {
-		    $indexTags = array_keys($Htag->topic_idx);
-		}
-		
-		$matchedTags = array();
-		
-		foreach($indexTags as $tag) {
-			foreach($tags as $tagExpr) {
-				if($this->preg_matchTag($tagExpr, $tag))
-					$matchedTags[] = $tag;
-			}
-		}
-		$matchedTags = array_unique($matchedTags);
-		foreach($matchedTags as $tag) {
-		    if($this->isNewTagVersion()) {
-		        $pages = $Htag->_tagIndexLookup(array($tag));
-		    } else {
-		        $pages = $Htag->topic_idx[$tag];
-		    }
-			$relations[$tag] = array_filter($pages,function($pageid) use ($ns) {
-				if ($ns === '' ||  (strpos(':'.getNS($pageid).':', ':'.$ns.':') === 0)) return true;
-			});
-		}
-		
-		$relations = array_filter($relations); //clean empty tags
-		ksort($relations); //sort
-		
-		return $relations;
-	}
+    /**
+     * @param string $tagExpression regexp pattern of wanted tags e.g. "status:.*"
+     * @return void
+     */
+    protected function addOrTag($tagExpression)
+    {
+        $tags = $this->getTagsByRegExp($tagExpression, $this->ps_ns);
+        $pages = array();
+        foreach ($tags as $t => $v) {
+            $Hpages = $this->Htag->getTopic($this->ps_ns, '', $t);
+            foreach ($Hpages as $p) {
+                $pages[] = $p['id'];
+                if (!isset($this->ps_pages[$p['id']])) {
+                    $this->ps_pages[$p['id']] = $p;
+                }
+            }
+        }
+        $pages = array_unique($pages);
+        $this->ps_pages_id = array_merge($this->ps_pages_id, $pages);
+        $this->ps_pages_id = array_unique($this->ps_pages_id);
+
+        //print_r($this->ps_pages_id);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getPages()
+    {
+        $ret = [];
+        foreach ($this->ps_pages_id as $id) {
+            $ret[] = $this->ps_pages[$id];
+        }
+        return $ret;
+    }
+
+    /**
+     * @param string $tag
+     * @return false|string
+     */
+    public function getImageLinkByTag($tag)
+    {
+        $id = $this->getConf('nsTagImage') . ':' . str_replace(array(' ', ':'), '_', $tag);
+        $src = $id . '.jpg';
+        if (!@file_exists(mediaFN($src))) {
+            $src = $id . '.png';
+            if (!@file_exists(mediaFN($src))) {
+                $src = $id . '.jpeg';
+                if (!@file_exists(mediaFN($src))) {
+                    $src = false;
+                }
+            }
+        }
+        if ($src !== false) {
+            return ml($src);
+        }
+        return false;
+    }
+
+    /**
+     * Generate html for in a cell of the column of the tags as images
+     *
+     * @param string $id pageid
+     * @param string $col tagexpression: regexp pattern of wanted tags e.g. "status:.*"
+     * @param string $ns namespace with images
+     * @return string html of tagimage(s) in cell
+     */
+    public function getTagImageColumn($id, $col, $ns)
+    {
+        if (!isset($this->tagsPerPage[$id])) {
+            $this->tagsPerPage[$id] = $this->getTagsByPageID($id);
+        }
+        $foundTags = [];
+        foreach ($this->tagsPerPage[$id] as $tag) {
+            if ($this->matchesTagExpression($col, $tag)) {
+                $foundTags[] = hsc($this->getTagLabel($tag));
+            }
+        }
+        $images = [];
+        foreach ($foundTags as $foundTag) {
+            $imageid = $ns . ':' . substr($foundTag, strrpos($foundTag, ':'));
+
+            $src = $imageid . '.jpg';
+            if (!@file_exists(mediaFN($src))) {
+                $src = $imageid . '.png';
+                if (!@file_exists(mediaFN($src))) {
+                    $src = $imageid . '.jpeg';
+                    if (!@file_exists(mediaFN($src))) {
+                        $src = $imageid . '.gif';
+                        if (!@file_exists(mediaFN($src))) {
+                            $src = false;
+                        }
+                    }
+                }
+            }
+            if ($src !== false) {
+                $images[] = '<img src="' . ml($src) . ' " class="media" style="height:max-width:200px;"/>';
+            }
+        }
+
+        return implode("<br>", $images);
+
+    }
+
+    /**
+     * return all pages defined by tag_list_r in a specific namespace
+     *
+     * @param string $ns the namespace to look in
+     * @param array $tag_list_r an array containing strings with tags seperated by ' '
+     *
+     */
+    public function getAllPages($ns, $tag_list_r)
+    {
+        $pages = array();
+        $pages[''] = '';
+
+        $tag_list = implode(' ', $tag_list_r);
+
+        $page_r = $this->getPagesByTags($ns, $tag_list);
+
+        foreach ($page_r as $page) {
+            $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
+            $title = $title ?: $page;
+            $pages[$page] = strip_tags($title);  //FIXME hsc() doesent work with chosen
+        }
+
+        asort($pages);
+        return $pages;
+    }
+
+    /**
+     * Returns page title, otherwise pageid
+     *
+     * @param string $pageid
+     * @return string
+     */
+    public function getPageTitle($pageid)
+    {
+        $title = p_get_metadata($pageid, 'title', METADATA_DONT_RENDER);
+        $title = $title ?: $pageid;
+        return strip_tags($title);
+    }
+
+    /**
+     * Gets the pages defined by tag_list
+     *
+     * partially copied from tag->helper with less checks (on cache) and no meta lookups
+     * @param string $ns the namespace to look in
+     * @param string $tag_list the tags separated by ' '
+     *
+     * @return array array of page ids
+     */
+    public function getPagesByTags($ns, $tag_list)
+    {
+        $tags_parsed = $this->Htag->_parseTagList($tag_list, true);
+        $pages_lookup = $this->Htag->_tagIndexLookup($tags_parsed);
+
+        $page_names = [];
+        foreach ($pages_lookup as $page_lookup) {
+            // filter by namespace, root namespace is identified with a dot // root namespace is specified, discard all pages who lay outside the root namespace
+            if (($ns == '.' && getNS($page_lookup) === false) || strpos(':' . getNS($page_lookup) . ':', ':' . $ns . ':') === 0 || $ns === '') {
+                $perm = auth_quickaclcheck($page_lookup);
+                if (!($perm < AUTH_READ)) {
+                    $page_names[] = $page_lookup;
+                }
+            }
+        }
+        return $page_names;
+    }
+
+    /**
+     * @param $tag
+     * @return string
+     */
+    public function getTagCategory($tag)
+    {
+        $label = strstr($tag, ':', true);
+        $label = $label != '' ? $label : $tag;
+        return PhpString::ucwords(str_replace('_', ' ', trim($label, ':')));
+    }
+
+    /**
+     * Used by pagelist plugin for filling the cell of the table header
+     *
+     * @param string $tag
+     * @return string
+     */
+    public function th($tag = '')
+    {
+        if (strpos($tag, '*')) {
+            return $this->getTagCategory($tag);
+        } else {
+            return $this->getTagLabel($tag);
+        }
+    }
+
+    /** @var array[] with pageid => array with tags */
+    protected $tagsPerPage = [];
+
+    /**
+     * Used by pagelist plugin for filling the cells of the table
+     * and in listing by the tagfilter
+     *
+     * @param string $id page id of row
+     * @param string $col tagexpression: regexp pattern of wanted tags e.g. "status:.*" as column name FIXME pagelist allows only one column!!! does not forward column name
+     * @return string
+     */
+    public function td($id, $col = null)
+    {
+        if (!isset($this->tagsPerPage[$id])) {
+            $this->tagsPerPage[$id] = $this->getTagsByPageID($id);
+        }
+        $foundTags = [];
+        foreach ($this->tagsPerPage[$id] as $tag) {
+            if ($this->matchesTagExpression($col, $tag)) {
+                $foundTags[] = hsc($this->getTagLabel($tag));
+            }
+        }
+        return implode("<br>", $foundTags);
+    }
+
+
+    /**
+     * Returns per tag the pages where these are used as array with: tag=>array with pages
+     * The tags matches the tag regexp pattern and only shown if it is used at pages in requested namespace, these pages
+     * are listed in an array per tag
+     *
+     * Does not check ACL
+     *
+     * @param string $tags tag expression e.g. "status:.*"
+     * @param string $ns list only pages from this namespace
+     * @return array [tag]=>array pages where tag is used
+     */
+    public function getPagesByMatchedTags($tags, $ns = '')
+    {
+
+        $Htag = $this->Htag;
+        if (!$Htag) return [];
+
+        $tags = $Htag->_parseTagList($tags, false); //array
+
+        $indexer = idx_get_indexer();
+        $indexTags = array_keys($indexer->histogram(1, 0, 3, 'subject'));
+
+        $matchedTags = [];
+        foreach ($indexTags as $tag) {
+            foreach ($tags as $tagExpr) {
+                if ($this->matchesTagExpression($tagExpr, $tag))
+                    $matchedTags[] = $tag;
+            }
+        }
+        $matchedTags = array_unique($matchedTags);
+
+        $matchedPages = [];
+        foreach ($matchedTags as $tag) {
+            $pages = $Htag->_tagIndexLookup([$tag]);
+
+            // keep only if in requested ns
+            $matchedPages[$tag] = array_filter($pages, function ($pageid) use ($ns) {
+                return $ns === '' || strpos(':' . getNS($pageid) . ':', ':' . $ns . ':') === 0;
+            });
+        }
+
+        //clean empty tags, because not in requested namespace
+        $matchedPages = array_filter($matchedPages);
+        ksort($matchedPages);
+
+        return $matchedPages;
+    }
 }
 

--- a/helper.php
+++ b/helper.php
@@ -185,7 +185,7 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
         $pages = $indexer->lookupKey('subject', $tag, [$this, 'tagCompare']);
 
         foreach ($pages as $page) {
-            if ($Htag->_isVisible($page, $ns)) {
+            if ($Htag->isVisible($page, $ns)) {
                 if (!$aclSafe) {
                     return true;
                 }
@@ -446,8 +446,8 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
      */
     public function getPagesByTags($ns, $tag_list)
     {
-        $tags_parsed = $this->Htag->_parseTagList($tag_list, true);
-        $pages_lookup = $this->Htag->_tagIndexLookup($tags_parsed);
+        $tags_parsed = $this->Htag->parseTagList($tag_list, true);
+        $pages_lookup = $this->Htag->getIndexedPagesMatchingTagQuery($tags_parsed);
 
         $page_names = [];
         foreach ($pages_lookup as $page_lookup) {
@@ -531,7 +531,7 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
         $Htag = $this->Htag;
         if (!$Htag) return [];
 
-        $tags = $Htag->_parseTagList($tags, false); //array
+        $tags = $Htag->parseTagList($tags, false); //array
 
         $indexer = idx_get_indexer();
         $indexTags = array_keys($indexer->histogram(1, 0, 3, 'subject'));
@@ -547,7 +547,7 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
 
         $matchedPages = [];
         foreach ($matchedTags as $tag) {
-            $pages = $Htag->_tagIndexLookup([$tag]);
+            $pages = $Htag->getIndexedPagesMatchingTagQuery([$tag]);
 
             // keep only if in requested ns
             $matchedPages[$tag] = array_filter($pages, function ($pageid) use ($ns) {

--- a/helper.php
+++ b/helper.php
@@ -91,7 +91,7 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
      */
     public function matchesTagExpression($tagExpression, $tag)
     {
-        return (bool) @preg_match('/^'.$tagExpression.'$/i', $tag);
+        return (bool)@preg_match('/^' . $tagExpression . '$/i', $tag);
     }
 
     /**
@@ -216,11 +216,11 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
         return file($fn, FILE_IGNORE_NEW_LINES);
     }
 
-    /** @var string  */
+    /** @var string */
     protected $ps_ns = '';
-    /** @var array  */
+    /** @var array */
     protected $ps_pages_id = [];
-    /** @var array  */
+    /** @var array */
     protected $ps_pages = [];
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -476,15 +476,15 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
     /**
      * Used by pagelist plugin for filling the cell of the table header
      *
-     * @param string $tag
+     * @param string $column column name is a tagexpression
      * @return string
      */
-    public function th($tag = '')
+    public function th($column = '')
     {
-        if (strpos($tag, '*')) {
-            return $this->getTagCategory($tag);
+        if (strpos($column, '*')) {
+            return $this->getTagCategory($column);
         } else {
-            return $this->getTagLabel($tag);
+            return $this->getTagLabel($column);
         }
     }
 
@@ -496,17 +496,20 @@ class helper_plugin_tagfilter extends DokuWiki_Plugin
      * and in listing by the tagfilter
      *
      * @param string $id page id of row
-     * @param string $col tagexpression: regexp pattern of wanted tags e.g. "status:.*" as column name FIXME pagelist allows only one column!!! does not forward column name
+     * @param string $column column name is a tagexpression: regexp pattern of wanted tags e.g. "status:.*". Supported since 2022 in pagelist plugin
      * @return string
      */
-    public function td($id, $col = null)
+    public function td($id, $column = null)
     {
+        if($column === null) {
+            return '';
+        }
         if (!isset($this->tagsPerPage[$id])) {
             $this->tagsPerPage[$id] = $this->getTagsByPageID($id);
         }
         $foundTags = [];
         foreach ($this->tagsPerPage[$id] as $tag) {
-            if ($this->matchesTagExpression($col, $tag)) {
+            if ($this->matchesTagExpression($column, $tag)) {
                 $foundTags[] = hsc($this->getTagLabel($tag));
             }
         }

--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -1,4 +1,5 @@
 <?php
+
 use dokuwiki\Cache\Cache;
 
 class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
@@ -27,42 +28,43 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
      *      - array $pageids ids of related pages
      *
      */
-    public function getTagPageRelations($opt) {
+    public function getTagPageRelations($opt)
+    {
         /* @var helper_plugin_tagfilter $Htagfilter */
         $Htagfilter = $this->loadHelper('tagfilter');
 
         $flags = $opt['tagfilterFlags'];
 
         $tagFilters = $opt['tagFilters'];
-        foreach($tagFilters['tagExpression'] as $key=>$tagExpression){ //build tag->pages relation
-            $tagFilters['pagesPerMatchedTags'][$key] = $Htagfilter->getPagesByMatchedTags($tagExpression,$opt['ns']);
+        foreach ($tagFilters['tagExpression'] as $key => $tagExpression) { //build tag->pages relation
+            $tagFilters['pagesPerMatchedTags'][$key] = $Htagfilter->getPagesByMatchedTags($tagExpression, $opt['ns']);
         }
 
         //extract all pageids
         $allPageids = [];
-        foreach($tagFilters['pagesPerMatchedTags'] as $pagesPerMatchedTag){
-            if(!is_array($pagesPerMatchedTag)) {
+        foreach ($tagFilters['pagesPerMatchedTags'] as $pagesPerMatchedTag) {
+            if (!is_array($pagesPerMatchedTag)) {
                 continue;
             }
-            foreach($pagesPerMatchedTag as $tag => $pageidsPerTag){
-                if(!empty($flags['withTags']) && !in_array($tag,$flags['withTags'])) {
+            foreach ($pagesPerMatchedTag as $tag => $pageidsPerTag) {
+                if (!empty($flags['withTags']) && !in_array($tag, $flags['withTags'])) {
                     continue;
                 }
-                if(!empty($flags['excludeTags']) && in_array($tag,$flags['excludeTags'])) {
+                if (!empty($flags['excludeTags']) && in_array($tag, $flags['excludeTags'])) {
                     continue;
                 }
-                $allPageids = array_merge($allPageids,$pageidsPerTag);
+                $allPageids = array_merge($allPageids, $pageidsPerTag);
             }
         }
 
-        $allPageids = array_filter($allPageids,function($val) use($opt){
+        $allPageids = array_filter($allPageids, function ($val) use ($opt) {
             //Template nicht anzeigen
-            if(strpos($val,'_template')!==false) {
+            if (strpos($val, '_template') !== false) {
                 return false;
             }
 
-            foreach($opt['tagfilterFlags']['excludeNs'] as $excludeNs) {
-                if(strpos($val, $excludeNs) === 0) {
+            foreach ($opt['tagfilterFlags']['excludeNs'] as $excludeNs) {
+                if (strpos($val, $excludeNs) === 0) {
                     return false;
                 }
             }
@@ -72,10 +74,10 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
         $allPageids = array_unique($allPageids); //TODO cache this
 
         //cache $pageids and $tagFilters for all users
-        return array(
+        return [
             $tagFilters,
             $allPageids
-        );
+        ];
     }
 
     /**
@@ -97,43 +99,43 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
      *          - for each tagcolumn: string '<tagexpr as column key>' html of cell
      *          - for each tagimagecolumn: string '<tagexpr as column key>' html of cell
      */
-    public function prepareList($pageids, $flags) {
+    public function prepareList($pageids, $flags)
+    {
         global $ID;
         global $INFO;
 
         /* @var helper_plugin_tagfilter $Htagfilter */
         $Htagfilter = $this->loadHelper('tagfilter');
 
-        if(!isset($flags['tagcolumn'])) {
-            $flags['tagcolumn'] = array();
+        if (!isset($flags['tagcolumn'])) {
+            $flags['tagcolumn'] = [];
         }
 
 
-
-        $pages = array();
+        $pages = [];
         $_uniqueid = 0;
-        foreach($pageids as $page){
+        foreach ($pageids as $page) {
 
-            $depends = ['files'=> [
+            $depends = ['files' => [
                 $INFO['filepath'],
                 wikiFN($page)
             ]];
-            $cache_key = 'plugin_tagfilter_'.$ID . '_' . $page;
+            $cache_key = 'plugin_tagfilter_' . $ID . '_' . $page;
             $cache = new Cache($cache_key, '.tpcache');
-            if(!$cache->useCache($depends)) {
+            if (!$cache->useCache($depends)) {
                 $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
 
                 $cache_page = [
-                    'title' => $title?:$page,
+                    'title' => $title ?: $page,
                     'id' => $page,
-                    'tmp_id' => $title?:(noNS($page)?:$page),
+                    'tmp_id' => $title ?: (noNS($page) ?: $page),
                 ];
 
-                foreach($flags['tagcolumn'] as $tagcolumn){
-                    $cache_page[hsc($tagcolumn)] = $Htagfilter->td($page,hsc($tagcolumn));
+                foreach ($flags['tagcolumn'] as $tagcolumn) {
+                    $cache_page[hsc($tagcolumn)] = $Htagfilter->td($page, hsc($tagcolumn));
                 }
-                foreach($flags['tagimagecolumn'] as $tagimagecolumn){
-                    $cache_page[hsc($tagimagecolumn[0]).' '] = $Htagfilter->getTagImageColumn($page,$tagimagecolumn[0], $tagimagecolumn[1]);
+                foreach ($flags['tagimagecolumn'] as $tagimagecolumn) {
+                    $cache_page[hsc($tagimagecolumn[0]) . ' '] = $Htagfilter->getTagImageColumn($page, $tagimagecolumn[0], $tagimagecolumn[1]);
                 }
                 $cache->storeCache(serialize($cache_page));
             } else {
@@ -142,18 +144,18 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
 
             //create unique key
             $tmp_id = $cache_page['tmp_id'];
-            if(isset($pages[$tmp_id])) {
-                $tmp_id .= '_'.$_uniqueid++;
+            if (isset($pages[$tmp_id])) {
+                $tmp_id .= '_' . $_uniqueid++;
             }
 
             $pages[$tmp_id] = $cache_page;
         }
 
 
-        if($flags['rsort']) {
-            krsort($pages,SORT_NATURAL|SORT_FLAG_CASE);
+        if ($flags['rsort']) {
+            krsort($pages, SORT_NATURAL | SORT_FLAG_CASE);
         } else {
-            ksort($pages,SORT_NATURAL|SORT_FLAG_CASE);
+            ksort($pages, SORT_NATURAL | SORT_FLAG_CASE);
         }
         return $pages;
     }
@@ -172,37 +174,37 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
      * @param array $pagelistflags all flags set by user
      * @return false|string
      */
-    public function renderList($pages, $flags, $pagelistflags) {
-          if(!isset($flags['tagcolumn'])) {
+    public function renderList($pages, $flags, $pagelistflags)
+    {
+        if (!isset($flags['tagcolumn'])) {
             $flags['tagcolumn'] = [];
         }
 
 
-
         // let Pagelist Plugin do the work for us
-        /* @var helper_plugin_pagelist $Hpagelist*/
+        /* @var helper_plugin_pagelist $Hpagelist */
         if (plugin_isdisabled('pagelist')
             || (!$Hpagelist = plugin_load('helper', 'pagelist'))) {
-                msg($this->getLang('missing_pagelistplugin'), -1);
-                return false;
-            }
+            msg($this->getLang('missing_pagelistplugin'), -1);
+            return false;
+        }
 
-            foreach($flags['tagcolumn'] as $tagcolumn) {
-                $Hpagelist->addColumn('tagfilter', hsc($tagcolumn));
-            }
-            foreach($flags['tagimagecolumn'] as $tagimagecolumn) {
-                $Hpagelist->addColumn('tagfilter', hsc($tagimagecolumn[0] . ' '));
-            }
+        foreach ($flags['tagcolumn'] as $tagcolumn) {
+            $Hpagelist->addColumn('tagfilter', hsc($tagcolumn));
+        }
+        foreach ($flags['tagimagecolumn'] as $tagimagecolumn) {
+            $Hpagelist->addColumn('tagfilter', hsc($tagimagecolumn[0] . ' '));
+        }
 
-            unset($flags['tagcolumn']);  //TODO unset is not needed because pagelistflags are separate array?
-            $Hpagelist->setFlags($pagelistflags);
-            $Hpagelist->startList();
+        unset($flags['tagcolumn']);  //TODO unset is not needed because pagelistflags are separate array?
+        $Hpagelist->setFlags($pagelistflags);
+        $Hpagelist->startList();
 
-            foreach ($pages as $page) {
-                $Hpagelist->addPage($page);
-            }
+        foreach ($pages as $page) {
+            $Hpagelist->addPage($page);
+        }
 
-            return $Hpagelist->finishList();
+        return $Hpagelist->finishList();
     }
 
 
@@ -216,7 +218,8 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
      *      multi, chosen, tagimage, pagesearch, pagesearchlabel, cache, rsort, labels, noneonclear, tagimagecolumn,
      *      tagcolumn (optional), excludeNs, withTags, excludeTags, images, count, tagintersect
      */
-    public function parseFlags($flags){
+    public function parseFlags($flags)
+    {
         $conf = [
             'multi' => false,
             'chosen' => false,
@@ -235,15 +238,15 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
             'count' => false,
             'tagintersect' => false,
         ];
-        if(!is_array($flags)) {
+        if (!is_array($flags)) {
             return $conf;
         }
 
-        foreach($flags as $flag) {
-            list($flag,$value) = array_pad(explode('=',$flag,2), 2, '');
+        foreach ($flags as $flag) {
+            list($flag, $value) = array_pad(explode('=', $flag, 2), 2, '');
             $flag = trim($flag);
             $value = trim($value);
-            switch($flag) {
+            switch ($flag) {
                 case 'multi':
                     $conf['multi'] = true;
                     break;
@@ -251,11 +254,11 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     $conf['chosen'] = true;
                     break;
                 case 'tagimage':
-                    $conf['tagimage']= true;
+                    $conf['tagimage'] = true;
                     break;
                 case 'pagesearch':
-                    $conf['pagesearch']= true;
-                    if($value != ''){
+                    $conf['pagesearch'] = true;
+                    if ($value != '') {
                         $conf['pagesearchlabel'] = hsc($value);
                     }
                     break;
@@ -269,7 +272,7 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     $conf['tagcolumn'][] = $value;
                     break;
                 case 'tagimagecolumn':
-                    $conf['tagimagecolumn'][] = explode('=', $value,2);
+                    $conf['tagimagecolumn'][] = explode('=', $value, 2);
                     break;
                 case 'rsort':
                     $conf['rsort'] = true;
@@ -281,13 +284,13 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     $conf['noneonclear'] = true;
                     break;
                 case 'excludeNs':
-                    $conf['excludeNs'] = explode(',', $value,2); //TODO really maximum of two namespaces?
+                    $conf['excludeNs'] = explode(',', $value, 2); //TODO really maximum of two namespaces?
                     break;
                 case 'withTags':
-                    $conf['withTags'] = explode(',', $value,2); //TODO really maximum of two tags?
+                    $conf['withTags'] = explode(',', $value, 2); //TODO really maximum of two tags?
                     break;
                 case 'excludeTags':
-                    $conf['excludeTags'] = explode(',', $value,2); //TODO really maximum of two tags?
+                    $conf['excludeTags'] = explode(',', $value, 2); //TODO really maximum of two tags?
                     break;
                 case 'images':
                     $conf['images'] = true;
@@ -319,24 +322,25 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
      *              return value is ignored for files
      * @author  Andreas Gohr <andi@splitbrain.org>
      */
-    public function search_all_pages(&$data,$base,$file,$type,$lvl,$opts){
+    public function search_all_pages(&$data, $base, $file, $type, $lvl, $opts)
+    {
         global $conf;
 
         //we do nothing with directories
-        if($type == 'd') {
+        if ($type == 'd') {
             return true;
         }
 
         //only search txt files
-        if(substr($file,-4) == '.txt'){
-            foreach($opts['excludeNs'] as $excludeNs) {
-                if(strpos($file, str_replace(':','/',$excludeNs)) === 0) {
+        if (substr($file, -4) == '.txt') {
+            foreach ($opts['excludeNs'] as $excludeNs) {
+                if (strpos($file, str_replace(':', '/', $excludeNs)) === 0) {
                     return true;
                 }
             }
 
             //check ACL
-            $data[] = $conf['datadir'].'/'.$file;
+            $data[] = $conf['datadir'] . '/' . $file;
         }
         return false;
     }

--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -1,79 +1,134 @@
 <?php
+use dokuwiki\Cache\Cache;
 
-class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin 
+class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
 {
-    function getTagPageRelations($opt) {
-        /* @var $Htagfilter helper_plugin_tagfilter */
+    /**
+     *
+     * @param array $opt
+     * with amongst others:
+     *      array 'tagfilterFlags' with:
+     *          string[] 'excludeNs',
+     *          string[] 'withTags' (optional),
+     *          string[] 'excludeTags (optional)
+     *      array 'tagFilters' with three arrays with same keys::
+     *          key=>string 'label'
+     *          key=>string 'tagExpression'
+     *          key=>array 'selectedTags'
+     *      - string 'ns'
+     * @return array
+     *  with
+     *      - array $tagFilters with four arrays with same key for each tagExpression:
+     *          key=>string 'label'
+     *          key=>string 'tagExpression'
+     *          key=>array 'selectedTags'
+     *          key=>array 'pagesPerMatchedTag' with
+     *              tag=>array of pageids of pages having the tag
+     *      - array $pageids ids of related pages
+     *
+     */
+    public function getTagPageRelations($opt) {
+        /* @var helper_plugin_tagfilter $Htagfilter */
         $Htagfilter = $this->loadHelper('tagfilter');
-    
-        $flags = $opt['tfFlags'];
-    
-        $tagselect_r = $opt['tagselect_r'];
-        foreach($tagselect_r['tag_expr'] as $key=>$tag_expr){ //build tag->pages relation
-            $tagselect_r['tagPages'][$key] = $Htagfilter->getRelationsByTagRegExp($tag_expr,$opt['ns']);
+
+        $flags = $opt['tagfilterFlags'];
+
+        $tagFilters = $opt['tagFilters'];
+        foreach($tagFilters['tagExpression'] as $key=>$tagExpression){ //build tag->pages relation
+            $tagFilters['pagesPerMatchedTags'][$key] = $Htagfilter->getPagesByMatchedTags($tagExpression,$opt['ns']);
         }
-    
+
         //extract all pageids
-        $pageids = array();
-        foreach($tagselect_r['tagPages'] as $select_r){
-            if(!is_array($select_r)) continue;
-            foreach($select_r as $tag => $pageid_r){
-                if(!empty($flags['withTags']) && !in_array($tag,$flags['withTags'])) continue;
-                if(!empty($flags['excludeTags']) && in_array($tag,$flags['excludeTags'])) continue;
-                $pageids = array_merge($pageids,$pageid_r);
+        $allPageids = [];
+        foreach($tagFilters['pagesPerMatchedTags'] as $pagesPerMatchedTag){
+            if(!is_array($pagesPerMatchedTag)) {
+                continue;
+            }
+            foreach($pagesPerMatchedTag as $tag => $pageidsPerTag){
+                if(!empty($flags['withTags']) && !in_array($tag,$flags['withTags'])) {
+                    continue;
+                }
+                if(!empty($flags['excludeTags']) && in_array($tag,$flags['excludeTags'])) {
+                    continue;
+                }
+                $allPageids = array_merge($allPageids,$pageidsPerTag);
             }
         }
-    
-        //Template nicht anzeigen
-        $pageids = array_filter($pageids,function($val) use($opt){
-            if(strpos($val,'_template')!==false) return false;
-            	
-            foreach($opt['tfFlags']['excludeNs'] as $excludeNs) {
-                if(strpos($val, $excludeNs) === 0) return false;
+
+        $allPageids = array_filter($allPageids,function($val) use($opt){
+            //Template nicht anzeigen
+            if(strpos($val,'_template')!==false) {
+                return false;
+            }
+
+            foreach($opt['tagfilterFlags']['excludeNs'] as $excludeNs) {
+                if(strpos($val, $excludeNs) === 0) {
+                    return false;
+                }
             }
             return true;
         });
-    
-            $pageids = array_unique($pageids); //TODO cache this
-    
-            //cache $pageids and $tagselect_r for all users
-            return array(
-                $tagselect_r,
-                $pageids
-    
-            );
+
+        $allPageids = array_unique($allPageids); //TODO cache this
+
+        //cache $pageids and $tagFilters for all users
+        return array(
+            $tagFilters,
+            $allPageids
+        );
     }
-    
+
+    /**
+     * Prepare array with data for each page suitable for displaying with the pagelist plugin
+     *
+     * @param array $pageids pages to list
+     * @param array $flags with
+     *      - array 'tagcolumn' (optional)
+     *          - string tagexpr
+     *      - array 'tagimagecolumn'
+     *          - string tagexpr
+     *          - string namespace of images
+     *      - bool 'rsort' whether reverse sort
+     * @return array[] with
+     *      - array with
+     *          - string 'title'
+     *          - string 'id' page id
+     *          - string 'tmp_id'
+     *          - for each tagcolumn: string '<tagexpr as column key>' html of cell
+     *          - for each tagimagecolumn: string '<tagexpr as column key>' html of cell
+     */
     public function prepareList($pageids, $flags) {
         global $ID;
         global $INFO;
-    
-        /* @var $Htagfilter helper_plugin_tagfilter */
+
+        /* @var helper_plugin_tagfilter $Htagfilter */
         $Htagfilter = $this->loadHelper('tagfilter');
-    
-        if(!isset($flags['tagcolumn']))$flags['tagcolumn'] = array();
-    
-    
-    
+
+        if(!isset($flags['tagcolumn'])) {
+            $flags['tagcolumn'] = array();
+        }
+
+
+
         $pages = array();
         $_uniqueid = 0;
         foreach($pageids as $page){
-            	
-            $depends = array('files'=>array(
+
+            $depends = ['files'=> [
                 $INFO['filepath'],
                 wikiFN($page)
-            ));
+            ]];
             $cache_key = 'plugin_tagfilter_'.$ID . '_' . $page;
-            $cache = new cache($cache_key, '.tpcache');
+            $cache = new Cache($cache_key, '.tpcache');
             if(!$cache->useCache($depends)) {
                 $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
-    
-                $cache_page = array(
-                    'title' => $title?$title:$page,
+
+                $cache_page = [
+                    'title' => $title?:$page,
                     'id' => $page,
-                    'tmp_id' => $title?$title:(noNS($page)?noNS($page):$page),
-                );
-    
+                    'tmp_id' => $title?:(noNS($page)?:$page),
+                ];
+
                 foreach($flags['tagcolumn'] as $tagcolumn){
                     $cache_page[hsc($tagcolumn)] = $Htagfilter->td($page,hsc($tagcolumn));
                 }
@@ -84,16 +139,17 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
             } else {
                 $cache_page = unserialize($cache->retrieveCache());
             }
-            	
+
+            //create unique key
             $tmp_id = $cache_page['tmp_id'];
             if(isset($pages[$tmp_id])) {
                 $tmp_id .= '_'.$_uniqueid++;
             }
-            	
+
             $pages[$tmp_id] = $cache_page;
         }
-    
-    
+
+
         if($flags['rsort']) {
             krsort($pages,SORT_NATURAL|SORT_FLAG_CASE);
         } else {
@@ -101,51 +157,67 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
         }
         return $pages;
     }
-    
-    
-    function renderList($pages, $flags,$pagelistflags) {
-        /* @var $Htagfilter helper_plugin_tagfilter */
-        $Htagfilter = $this->loadHelper('tagfilter');
-    
-        if(!isset($flags['tagcolumn']))$flags['tagcolumn'] = array();
-    
-    
-    
+
+
+    /**
+     * Generated list of the give page data
+     *
+     * @param array $pages for format @see prepareList()
+     * @param array $flags tagfilter flags with at least:
+     *      - array 'tagcolumn' (optional)
+     *          - string tagexpr
+     *      - array 'tagimagecolumn'
+     *          - string tagexpr
+     *          - string namespace of images
+     * @param array $pagelistflags all flags set by user
+     * @return false|string
+     */
+    public function renderList($pages, $flags, $pagelistflags) {
+          if(!isset($flags['tagcolumn'])) {
+            $flags['tagcolumn'] = [];
+        }
+
+
+
         // let Pagelist Plugin do the work for us
+        /* @var helper_plugin_pagelist $Hpagelist*/
         if (plugin_isdisabled('pagelist')
             || (!$Hpagelist = plugin_load('helper', 'pagelist'))) {
                 msg($this->getLang('missing_pagelistplugin'), -1);
                 return false;
             }
-    
+
             foreach($flags['tagcolumn'] as $tagcolumn) {
-                $Hpagelist->addColumn('tagfilter',hsc($tagcolumn));
+                $Hpagelist->addColumn('tagfilter', hsc($tagcolumn));
             }
             foreach($flags['tagimagecolumn'] as $tagimagecolumn) {
                 $Hpagelist->addColumn('tagfilter', hsc($tagimagecolumn[0] . ' '));
             }
-            	
-            unset($flags['tagcolumn']);
+
+            unset($flags['tagcolumn']);  //TODO unset is not needed because pagelistflags are separate array?
             $Hpagelist->setFlags($pagelistflags);
             $Hpagelist->startList();
-    
+
             foreach ($pages as $page) {
                 $Hpagelist->addPage($page);
             }
-    
-    
+
             return $Hpagelist->finishList();
     }
-    
-    
-    /*
+
+
+    /**
      * parseFlags checks for tagfilter flags and returns them as true/false
-     * @param $flags array
-     * @return array tagfilter flags
+     *
+     * @param array $flags array with (all optional):
+     *      multi, chosen, tagimage, pagesearch, cacheage, nocache, rsort, nolabels, noneonclear, tagimagecolumn,
+     *      tagcolumn, excludeNs, withTags, excludeTags, images, count, tagintersect
+     * @return array tagfilter flags with:
+     *      multi, chosen, tagimage, pagesearch, pagesearchlabel, cache, rsort, labels, noneonclear, tagimagecolumn,
+     *      tagcolumn (optional), excludeNs, withTags, excludeTags, images, count, tagintersect
      */
-    function parseFlags($flags){
-        if(!is_array($flags)) return false;
-        $conf = array(
+    public function parseFlags($flags){
+        $conf = [
             'multi' => false,
             'chosen' => false,
             'tagimage' => false,
@@ -155,17 +227,20 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
             'rsort' => false,
             'labels' => true,
             'noneonclear' => false,
-            'tagimagecolumn' => array(),
-            'excludeNs' => array(),
-            'withTags' => array(),
-            'excludeTags' => array(),
+            'tagimagecolumn' => [],
+            'excludeNs' => [],
+            'withTags' => [],
+            'excludeTags' => [],
             'images' => false,
             'count' => false,
             'tagintersect' => false,
-        );
-    
-        foreach($flags as $k=>$flag) {
-            list($flag,$value) = explode('=',$flag,2);
+        ];
+        if(!is_array($flags)) {
+            return $conf;
+        }
+
+        foreach($flags as $flag) {
+            list($flag,$value) = array_pad(explode('=',$flag,2), 2, '');
             $flag = trim($flag);
             $value = trim($value);
             switch($flag) {
@@ -206,13 +281,13 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     $conf['noneonclear'] = true;
                     break;
                 case 'excludeNs':
-                    $conf['excludeNs'] = explode(',', $value,2);
+                    $conf['excludeNs'] = explode(',', $value,2); //TODO really maximum of two namespaces?
                     break;
                 case 'withTags':
-                    $conf['withTags'] = explode(',', $value,2);
+                    $conf['withTags'] = explode(',', $value,2); //TODO really maximum of two tags?
                     break;
                 case 'excludeTags':
-                    $conf['excludeTags'] = explode(',', $value,2);
+                    $conf['excludeTags'] = explode(',', $value,2); //TODO really maximum of two tags?
                     break;
                 case 'images':
                     $conf['images'] = true;
@@ -225,28 +300,41 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     break;
             }
         }
-    
+
         return $conf;
     }
-    
-    
+
+
     /**
      * This function just lists documents (for RSS namespace export)
      *
+     * @param array $data Reference to the result data structure
+     * @param string $base Base usually $conf['datadir']
+     * @param string $file current file or directory relative to $base
+     * @param string $type Type either 'd' for directory or 'f' for file
+     * @param int $lvl Current recursion depth
+     * @param array $opts option array as given to search() with:
+     *      string[] 'excludeNs'
+     * @return bool if this directory should be traversed (true) or not (false)
+     *              return value is ignored for files
      * @author  Andreas Gohr <andi@splitbrain.org>
      */
-    function search_all_pages(&$data,$base,$file,$type,$lvl,$opts){
+    public function search_all_pages(&$data,$base,$file,$type,$lvl,$opts){
         global $conf;
-    
+
         //we do nothing with directories
-        if($type == 'd') return true;
-    
+        if($type == 'd') {
+            return true;
+        }
+
         //only search txt files
         if(substr($file,-4) == '.txt'){
             foreach($opts['excludeNs'] as $excludeNs) {
-                if(strpos($file, str_replace(':','/',$excludeNs)) === 0) return true;
+                if(strpos($file, str_replace(':','/',$excludeNs)) === 0) {
+                    return true;
+                }
             }
-    
+
             //check ACL
             $data[] = $conf['datadir'].'/'.$file;
         }

--- a/remote.php
+++ b/remote.php
@@ -1,4 +1,7 @@
 <?php
+
+use dokuwiki\Remote\AccessDeniedException;
+
 class remote_plugin_tagfilter extends DokuWiki_Remote_Plugin {
     public function _getMethods() {
         return array(
@@ -8,73 +11,84 @@ class remote_plugin_tagfilter extends DokuWiki_Remote_Plugin {
             )*/
         );
     }
-    
+
+    /**
+     * @throws AccessDeniedException
+     */
     public function getTagsByPage($id) {
         if(auth_quickaclcheck($id) < AUTH_READ){
-            throw new RemoteAccessDeniedException('You are not allowed to read this file', 111);
+            throw new AccessDeniedException('You are not allowed to read this file', 111);
         }
-        
-        $Htagfilter = $this->loadHelper('tagfilter',false);
-        if(!$Htagfilter) {
-            /*Exeption*/
-            throw new RemoteAccessDeniedException('problem with helper plugin', 99999);
-        } 
-        return $Htagfilter->getTagsBySiteID($id);
-    }
-    
-    public function getPagesByTags($tags,$ns='') {  
 
+        /** @var helper_plugin_tagfilter $Htagfilter */
         $Htagfilter = $this->loadHelper('tagfilter',false);
         if(!$Htagfilter) {
             /*Exeption*/
-            throw new RemoteAccessDeniedException('problem with helper plugin', 99999);
-        } 
+            throw new AccessDeniedException('problem with helper plugin', 99999);
+        }
+        return $Htagfilter->getTagsByPageID($id);
+    }
+
+    /**
+     * @throws AccessDeniedException
+     */
+    public function getPagesByTags($tags, $ns='') {
+
+        /** @var helper_plugin_tagfilter $Htagfilter */
+        $Htagfilter = $this->loadHelper('tagfilter',false);
+        if(!$Htagfilter) {
+            /*Exeption*/
+            throw new AccessDeniedException('problem with helper plugin', 99999);
+        }
 
         $pages =  $Htagfilter->getPagesByTags($ns,$tags);
 
         //$pages_cleaned = array_intersect_key($pages, array_flip('id','title'));
-        $pages_r = array();
-        
+        $pages_r = [];
+
         foreach($pages as $page){
             $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
-            $pages_r[] = array(
-                'title' => $title?$title:$page,
+            $pages_r[] = [
+                'title' => $title?:$page,
                 'id' => $page,
-                'tags' => $Htagfilter->getTagsBySiteID($page)
-                );
+                'tags' => $Htagfilter->getTagsByPageID($page)
+            ];
         }
-        
+
         return $pages_r;
     }
-	
-	public function getPagesByRegExpTags($tags,$ns='') {  
 
+    /**
+     * @throws AccessDeniedException
+     */
+    public function getPagesByRegExpTags($tags, $ns='') {
+        /** @var helper_plugin_tagfilter $Htagfilter */
         $Htagfilter = $this->loadHelper('tagfilter',false);
         if(!$Htagfilter) {
             /*Exeption*/
-            throw new RemoteAccessDeniedException('problem with helper plugin', 99999);
-        } 
+            throw new AccessDeniedException('problem with helper plugin', 99999);
+        }
 
 
-		$tags_r = $Htagfilter->getTagsByRegExp($tags,$ns);
-		$tags_r = array_keys($tags_r);
+		$tags_labels = $Htagfilter->getTagsByRegExp($tags,$ns);
+		$tags_r = array_keys($tags_labels);
         $pages =  $Htagfilter->getPagesByTags($ns,implode(' ',$tags_r));
 
         //$pages_cleaned = array_intersect_key($pages, array_flip('id','title'));
-        $pages_r = array();
-        
+        $pages_r = [];
+
         foreach($pages as $page){
             $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
-            $pages_r[] = array(
-                'title' => $title?$title:$page,
+            $pages_r[] = [
+                'title' => $title?:$page,
                 'id' => $page,
-                'tags' => $Htagfilter->getTagsBySiteID($page)
-                );
+                'tags' => $Htagfilter->getTagsByPageID($page)
+            ];
         }
-        
+
         return $pages_r;
     }
-    
-    
-    
+
+
+
 }

--- a/remote.php
+++ b/remote.php
@@ -2,27 +2,29 @@
 
 use dokuwiki\Remote\AccessDeniedException;
 
-class remote_plugin_tagfilter extends DokuWiki_Remote_Plugin {
-    public function _getMethods() {
-        return array(
-            /*'getTagsById'=>array(
+class remote_plugin_tagfilter extends DokuWiki_Remote_Plugin
+{
+    public function _getMethods()
+    {
+        return [/*'getTagsById'=>array(
                 'args'=>array('id'),
                 'return'=>'array'
             )*/
-        );
+        ];
     }
 
     /**
      * @throws AccessDeniedException
      */
-    public function getTagsByPage($id) {
-        if(auth_quickaclcheck($id) < AUTH_READ){
+    public function getTagsByPage($id)
+    {
+        if (auth_quickaclcheck($id) < AUTH_READ) {
             throw new AccessDeniedException('You are not allowed to read this file', 111);
         }
 
         /** @var helper_plugin_tagfilter $Htagfilter */
-        $Htagfilter = $this->loadHelper('tagfilter',false);
-        if(!$Htagfilter) {
+        $Htagfilter = $this->loadHelper('tagfilter', false);
+        if (!$Htagfilter) {
             /*Exeption*/
             throw new AccessDeniedException('problem with helper plugin', 99999);
         }
@@ -32,24 +34,25 @@ class remote_plugin_tagfilter extends DokuWiki_Remote_Plugin {
     /**
      * @throws AccessDeniedException
      */
-    public function getPagesByTags($tags, $ns='') {
+    public function getPagesByTags($tags, $ns = '')
+    {
 
         /** @var helper_plugin_tagfilter $Htagfilter */
-        $Htagfilter = $this->loadHelper('tagfilter',false);
-        if(!$Htagfilter) {
+        $Htagfilter = $this->loadHelper('tagfilter', false);
+        if (!$Htagfilter) {
             /*Exeption*/
             throw new AccessDeniedException('problem with helper plugin', 99999);
         }
 
-        $pages =  $Htagfilter->getPagesByTags($ns,$tags);
+        $pages = $Htagfilter->getPagesByTags($ns, $tags);
 
         //$pages_cleaned = array_intersect_key($pages, array_flip('id','title'));
         $pages_r = [];
 
-        foreach($pages as $page){
+        foreach ($pages as $page) {
             $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
             $pages_r[] = [
-                'title' => $title?:$page,
+                'title' => $title ?: $page,
                 'id' => $page,
                 'tags' => $Htagfilter->getTagsByPageID($page)
             ];
@@ -61,26 +64,27 @@ class remote_plugin_tagfilter extends DokuWiki_Remote_Plugin {
     /**
      * @throws AccessDeniedException
      */
-    public function getPagesByRegExpTags($tags, $ns='') {
+    public function getPagesByRegExpTags($tags, $ns = '')
+    {
         /** @var helper_plugin_tagfilter $Htagfilter */
-        $Htagfilter = $this->loadHelper('tagfilter',false);
-        if(!$Htagfilter) {
+        $Htagfilter = $this->loadHelper('tagfilter', false);
+        if (!$Htagfilter) {
             /*Exeption*/
             throw new AccessDeniedException('problem with helper plugin', 99999);
         }
 
 
-		$tags_labels = $Htagfilter->getTagsByRegExp($tags,$ns);
-		$tags_r = array_keys($tags_labels);
-        $pages =  $Htagfilter->getPagesByTags($ns,implode(' ',$tags_r));
+        $tags_labels = $Htagfilter->getTagsByRegExp($tags, $ns);
+        $tags_r = array_keys($tags_labels);
+        $pages = $Htagfilter->getPagesByTags($ns, implode(' ', $tags_r));
 
         //$pages_cleaned = array_intersect_key($pages, array_flip('id','title'));
         $pages_r = [];
 
-        foreach($pages as $page){
+        foreach ($pages as $page) {
             $title = p_get_metadata($page, 'title', METADATA_DONT_RENDER);
             $pages_r[] = [
-                'title' => $title?:$page,
+                'title' => $title ?: $page,
                 'id' => $page,
                 'tags' => $Htagfilter->getTagsByPageID($page)
             ];
@@ -88,7 +92,6 @@ class remote_plugin_tagfilter extends DokuWiki_Remote_Plugin {
 
         return $pages_r;
     }
-
 
 
 }

--- a/syntax/compare.php
+++ b/syntax/compare.php
@@ -1,4 +1,5 @@
 <?php
+
 use dokuwiki\Form\Form;
 
 /**
@@ -8,181 +9,187 @@ use dokuwiki\Form\Form;
  * @author  lisps
  */
 
-/*
- * All DokuWiki plugins to extend the parser/rendering mechanism
- * need to inherit from this class
- */
-class syntax_plugin_tagfilter_compare extends syntax_plugin_tagfilter_filter {
+class syntax_plugin_tagfilter_compare extends syntax_plugin_tagfilter_filter
+{
 
     /*
      * What kind of syntax are we?
      */
-    function getType() {return 'substition';}
+    function getType()
+    {
+        return 'substition';
+    }
 
     /*
      * Where to sort in?
      */
-    function getSort() {return 155;}
+    function getSort()
+    {
+        return 155;
+    }
 
     /*
      * Paragraph Type
      */
-    function getPType(){return 'block';}
+    function getPType()
+    {
+        return 'block';
+    }
 
     /*
      * Connect pattern to lexer
      */
-    function connectTo($mode) {
-		$this->Lexer->addSpecialPattern("\{\{tagcompare>.*?\}\}",$mode,'plugin_tagfilter_compare');
-	}
+    function connectTo($mode)
+    {
+        $this->Lexer->addSpecialPattern("\{\{tagcompare>.*?\}\}", $mode, 'plugin_tagfilter_compare');
+    }
 
     /*
      * Handle the matches
      */
-    function handle($match, $state, $pos, Doku_Handler $handler) {
-        $match=trim(substr($match,13,-2));
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
+        $match = trim(substr($match, 13, -2));
 
-        return $this->getOpts($match) ;
+        return $this->getOpts($match);
     }
 
     /*
      * Create output
      */
     function render($format, Doku_Renderer $renderer, $opt)
-	{
-		global $ID;
-		global $INPUT;
+    {
+        global $ID;
+        global $INPUT;
 
-		$flags = $opt['tagfilterFlags'];
-		if($format === 'metadata') return false;
-		if($format === 'xhtml') {
-			$renderer->nocache();
+        $flags = $opt['tagfilterFlags'];
+        if ($format === 'metadata') return false;
+        if ($format === 'xhtml') {
+            $renderer->nocache();
 
-			/* @var helper_plugin_tagfilter $Htagfilter */
-			$Htagfilter = $this->loadHelper('tagfilter');
+            /* @var helper_plugin_tagfilter $Htagfilter */
+            $Htagfilter = $this->loadHelper('tagfilter');
             /* @var helper_plugin_tagfilter_syntax $HtagfilterSyntax */
             $HtagfilterSyntax = $this->loadHelper('tagfilter_syntax');
-			$renderer->cdata("\n");
+            $renderer->cdata("\n");
 
 
             list($tagFilters, $allPageids) = $HtagfilterSyntax->getTagPageRelations($opt);
             $preparedPages = $HtagfilterSyntax->prepareList($allPageids, $flags);
 
-			//check for read access
-			foreach($allPageids as $key=>$pageid) {
-				if(! $Htagfilter->canRead($pageid)) {
-					unset($allPageids[$key]);
-				}
-			}
+            //check for read access
+            foreach ($allPageids as $key => $pageid) {
+                if (!$Htagfilter->canRead($pageid)) {
+                    unset($allPageids[$key]);
+                }
+            }
 
-			//check tags for visibility
-			foreach($tagFilters['pagesPerMatchedTags'] as $pagesPerMatchedTag) {
-				foreach($pagesPerMatchedTag as $tag => $pageidsPerTag) {
-					if(count(array_intersect($pageidsPerTag, $allPageids)) == 0) {
-						unset($pagesPerMatchedTag[$tag]);
-					}
-				}
-			}
+            //check tags for visibility
+            foreach ($tagFilters['pagesPerMatchedTags'] as $pagesPerMatchedTag) {
+                foreach ($pagesPerMatchedTag as $tag => $pageidsPerTag) {
+                    if (count(array_intersect($pageidsPerTag, $allPageids)) == 0) {
+                        unset($pagesPerMatchedTag[$tag]);
+                    }
+                }
+            }
 
-			$dropdownValues = [''=>''];
-			foreach($preparedPages as $key=>$page) {
-				if(!in_array($page['id'],$allPageids)) {
-					unset($preparedPages[$key]);
-				}
-				$dropdownValues[$page['id']] = $page['title'];
-			}
+            $dropdownValues = ['' => ''];
+            foreach ($preparedPages as $key => $page) {
+                if (!in_array($page['id'], $allPageids)) {
+                    unset($preparedPages[$key]);
+                }
+                $dropdownValues[$page['id']] = $page['title'];
+            }
 
-			//dbg($INPUT->arr('tagcompare_page'));
-			$selectedValues = $INPUT->arr('tagcompare_page');
+            //dbg($INPUT->arr('tagcompare_page'));
+            $selectedValues = $INPUT->arr('tagcompare_page');
             var_dump($selectedValues);
-			echo '<div class="table plugin_tagcompare">';
-			$form = new Doku_Form(array(
-			    'id'=>'tagcomparedd_'.$opt['id'],
-			    'data-plugin'=>'tagcompare',
-			    'method' => 'GET',
-			));
-			$form->addHidden('id', $ID);
-			$form->addElement('<table>');
-			$form->addElement('<thead>');
-			$form->addElement('<tr>');
-			$form->addElement('<th>');
-			$form->addElement(hsc('Tags'));
-			$form->addElement('</th>');
+            echo '<div class="table plugin_tagcompare">';
+            $form = new Doku_Form([
+                'id' => 'tagcomparedd_' . $opt['id'],
+                'data-plugin' => 'tagcompare',
+                'method' => 'GET',
+            ]);
+            $form->addHidden('id', $ID);
+            $form->addElement('<table>');
+            $form->addElement('<thead>');
+            $form->addElement('<tr>');
+            $form->addElement('<th>');
+            $form->addElement(hsc('Tags'));
+            $form->addElement('</th>');
 
-            for($ii = 0; $ii < 4; $ii++) {
+            for ($ii = 0; $ii < 4; $ii++) {
                 $form->addElement('<th>');
-                $form->addElement(form_makeListboxField('tagcompare_page['.$ii.']', $dropdownValues, $selectedValues[$ii] ?? null, '', '', 'tagcompare' , array()));
+                $form->addElement(form_makeListboxField('tagcompare_page[' . $ii . ']', $dropdownValues, $selectedValues[$ii] ?? null, '', '', 'tagcompare', []));
                 $form->addElement('</th>');
             }
             $form->addElement('</tr>');
             $form->addElement('</thead>');
 
-			$form->addElement('<tbody>');
+            $form->addElement('<tbody>');
 
-			if($flags['images']) {
-			    /** @var helper_plugin_pageimage $HPageimage */
-			    $HPageimage = $this->loadHelper('pageimage');
-    			$form->addElement('<tr>');
-    			$form->addElement('<th></th>');
-    			for($ii = 0; $ii < 4; $ii++) {
-    			    $form->addElement('<td>');
-    			    if(!empty($selectedValues[$ii])) {
-    			        $form->addElement($HPageimage->td($selectedValues[$ii], ['firstimage' => true])); //fixme pageimage->td() does not accept flags as 2nd arg.
-    			    }
-    			    $form->addElement('</td>');
-    			}
-    			$form->addElement('</tr>');
-			}
+            if ($flags['images']) {
+                /** @var helper_plugin_pageimage $HPageimage */
+                $HPageimage = $this->loadHelper('pageimage');
+                $form->addElement('<tr>');
+                $form->addElement('<th></th>');
+                for ($ii = 0; $ii < 4; $ii++) {
+                    $form->addElement('<td>');
+                    if (!empty($selectedValues[$ii])) {
+                        $form->addElement($HPageimage->td($selectedValues[$ii], ['firstimage' => true])); //fixme pageimage->td() does not accept flags as 2nd arg.
+                    }
+                    $form->addElement('</td>');
+                }
+                $form->addElement('</tr>');
+            }
             // for each tagexpression a row is added, where tags that match the tagexpression are shown if they are also
             // used on the page selected for that table column
-            foreach($tagFilters['pagesPerMatchedTags'] as $idx => $pagesPerMatchedTag) {
-			    $form->addElement('<tr>');
-			    $form->addElement('<th>');
-			    $form->addElement(hsc($tagFilters['label'][$idx]));
-			    $form->addElement('</th>');
+            foreach ($tagFilters['pagesPerMatchedTags'] as $idx => $pagesPerMatchedTag) {
+                $form->addElement('<tr>');
+                $form->addElement('<th>');
+                $form->addElement(hsc($tagFilters['label'][$idx]));
+                $form->addElement('</th>');
 
-			    for($ii = 0; $ii < 4; $ii++) {
-			        $form->addElement('<td>');
+                for ($ii = 0; $ii < 4; $ii++) {
+                    $form->addElement('<td>');
                     //more tags per cell(=per page) possible
-			        foreach($pagesPerMatchedTag as $tagName => $pageidsPerTag) {
-    			        if(isset($selectedValues[$ii]) & in_array($selectedValues[$ii], $pageidsPerTag)) {
-    			             $form->addElement(hsc($Htagfilter->getTagLabel($tagName)). '<br>');
-    			        }
-			        }
-			        $form->addElement('</td>');
-			    }
+                    foreach ($pagesPerMatchedTag as $tagName => $pageidsPerTag) {
+                        if (isset($selectedValues[$ii]) & in_array($selectedValues[$ii], $pageidsPerTag)) {
+                            $form->addElement(hsc($Htagfilter->getTagLabel($tagName)) . '<br>');
+                        }
+                    }
+                    $form->addElement('</td>');
+                }
 
-			    $form->addElement('</tr>');
-			}
+                $form->addElement('</tr>');
+            }
 
-			$form->addElement('<tr>');
-			$form->addElement('<th>');
-			$form->addElement('Link');
-			$form->addElement('</th>');
+            $form->addElement('<tr>');
+            $form->addElement('<th>');
+            $form->addElement('Link');
+            $form->addElement('</th>');
 
-			for($ii = 0; $ii < 4; $ii++) {
+            for ($ii = 0; $ii < 4; $ii++) {
 
-			    $form->addElement('<th>');
+                $form->addElement('<th>');
 
                 if (!empty($selectedValues[$ii])) {
                     $form->addElement('<a href="' . wl($selectedValues[$ii]) . '" class="wikilink1">Link</a>');
                 }
 
-			    $form->addElement('</th>');
+                $form->addElement('</th>');
 
-			}
-			$form->addElement('</tr>');
+            }
+            $form->addElement('</tr>');
 
-			$form->addElement('</tbody>');
-			$form->addElement('</table>');
-			$form->addElement('</div>');
-
-
-			$renderer->doc .= $form->getForm();
-		}
-		return true;
-	}
+            $form->addElement('</tbody>');
+            $form->addElement('</table>');
+            $form->addElement('</div>');
 
 
+            $renderer->doc .= $form->getForm();
+        }
+        return true;
+    }
 
 }

--- a/syntax/compare.php
+++ b/syntax/compare.php
@@ -2,37 +2,18 @@
 use dokuwiki\Form\Form;
 
 /**
- * DokuWiki Plugin tagfilter (Syntax Component) 
+ * DokuWiki Plugin tagfilter (Syntax Component)
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author  lisps    
+ * @author  lisps
  */
 
 /*
  * All DokuWiki plugins to extend the parser/rendering mechanism
  * need to inherit from this class
  */
-class syntax_plugin_tagfilter_compare extends DokuWiki_Syntax_Plugin {
+class syntax_plugin_tagfilter_compare extends syntax_plugin_tagfilter_filter {
 
-    private $_itemPos = array();
-    function incItemPos() {
-        global $ID;
-        if(array_key_exists($ID,$this->_itemPos)) {
-            return $this->_itemPos[$ID]++;
-        } else {
-            $this->_itemPos[$ID] = 1;
-            return 0;
-        }
-    }
-    function getItemPos(){
-        global $ID;
-        if(array_key_exists($ID,$this->_itemPos)) {
-            $this->_itemPos[$ID];
-        } else {
-            return 0;
-        }
-    }
-	
     /*
      * What kind of syntax are we?
      */
@@ -59,105 +40,64 @@ class syntax_plugin_tagfilter_compare extends DokuWiki_Syntax_Plugin {
      * Handle the matches
      */
     function handle($match, $state, $pos, Doku_Handler $handler) {
-		global $ID;
-		$HtagfilterSyntax = $this->loadHelper('tagfilter_syntax');
-		$opts['id']=$this->incItemPos();
+        $match=trim(substr($match,13,-2));
 
-		$match=trim(substr($match,13,-2));
-
-        list($match, $flags) = explode('&', $match, 2);
-        $flags = explode('&', $flags);
-        list($ns, $tag) = explode('?', $match);
-
-        if (!$tag) {
-            $tag = $ns;
-            $ns   = '';
-        }
-
-        if (($ns == '*') || ($ns == ':')) $ns = '';
-        elseif ($ns == '.') $ns = getNS($ID);
-        else $ns = cleanID($ns);
-		
-		$opts['ns']=$ns;
-		
-		//only flags for tagfilter 
-		$opts['tfFlags'] = $HtagfilterSyntax->parseFlags($flags);
-		
-		//all flags for pagelist plugin
-		$opts['flags']=array_map('trim',$flags);
-		
-		//read and parse tag 
-		$tagselect_r = array();
-		$select_expr_r = array_map('trim',explode('|',$tag));
-		foreach($select_expr_r as $key=>$usr_syntax){
-			$usr_syntax = explode("=",$usr_syntax);//aufsplitten in Label,RegExp,DefaultWert
-				
-			$tagselect_r['label'][$key]  = trim($usr_syntax[0]);
-			$tagselect_r['tag_expr'][$key]  = trim($usr_syntax[1]);
-			$tagselect_r['selectedTags'][$key] = isset($usr_syntax[2])?explode(' ',$usr_syntax[2]):array();
-		}
-		
-		$opts['tagselect_r'] = $tagselect_r;
-		
-		return ($opts);
+        return $this->getOpts($match) ;
     }
-            
-    /* 
+
+    /*
      * Create output
      */
-    function render($mode, Doku_Renderer $renderer, $opt)
+    function render($format, Doku_Renderer $renderer, $opt)
 	{
-		global $INFO;
 		global $ID;
 		global $INPUT;
-		global $USERINFO;
-		global $conf;
 
-		$flags = $opt['tfFlags'];
-		if($mode === 'metadata') return false;
-		if($mode === 'xhtml') {
-			$renderer->info['cache'] = false;
-			
-			/* @var $Htagfilter helper_plugin_tagfilter */
+		$flags = $opt['tagfilterFlags'];
+		if($format === 'metadata') return false;
+		if($format === 'xhtml') {
+			$renderer->nocache();
+
+			/* @var helper_plugin_tagfilter $Htagfilter */
 			$Htagfilter = $this->loadHelper('tagfilter');
-			$HtagfilterSyntax = $this->loadHelper('tagfilter_syntax');
+            /* @var helper_plugin_tagfilter_syntax $HtagfilterSyntax */
+            $HtagfilterSyntax = $this->loadHelper('tagfilter_syntax');
 			$renderer->cdata("\n");
 
 
-			$cachedata = $HtagfilterSyntax->getTagPageRelations($opt);
-			$cachedata[] = $HtagfilterSyntax->prepareList($cachedata[1],$flags);
+            list($tagFilters, $allPageids) = $HtagfilterSyntax->getTagPageRelations($opt);
+            $preparedPages = $HtagfilterSyntax->prepareList($allPageids, $flags);
 
-			list($tagselect_r, $pageids, $preparedPages) = $cachedata;
-			
 			//check for read access
-			foreach($pageids as $key=>$pageid) {
+			foreach($allPageids as $key=>$pageid) {
 				if(! $Htagfilter->canRead($pageid)) {
-					unset($pageids[$key]);
+					unset($allPageids[$key]);
 				}
 			}
-			
+
 			//check tags for visibility
-			foreach($tagselect_r['tagPages'] as &$select_r) {
-				foreach($select_r as $tag=>$pageid_r) {
-					if(count(array_intersect(($pageid_r), $pageids)) == 0) {
-						unset($select_r[$tag]);
+			foreach($tagFilters['pagesPerMatchedTags'] as $pagesPerMatchedTag) {
+				foreach($pagesPerMatchedTag as $tag => $pageidsPerTag) {
+					if(count(array_intersect($pageidsPerTag, $allPageids)) == 0) {
+						unset($pagesPerMatchedTag[$tag]);
 					}
 				}
 			}
-			
-			$dropdownValues = array(''=>'');
+
+			$dropdownValues = [''=>''];
 			foreach($preparedPages as $key=>$page) {
-				if(!in_array($page['id'],$pageids)) {
+				if(!in_array($page['id'],$allPageids)) {
 					unset($preparedPages[$key]);
 				}
 				$dropdownValues[$page['id']] = $page['title'];
 			}
-			
+
 			//dbg($INPUT->arr('tagcompare_page'));
 			$selectedValues = $INPUT->arr('tagcompare_page');
+            var_dump($selectedValues);
 			echo '<div class="table plugin_tagcompare">';
 			$form = new Doku_Form(array(
-			    'id'=>'tagcomparedd_'.$ii,
+			    'id'=>'tagcomparedd_'.$opt['id'],
 			    'data-plugin'=>'tagcompare',
 			    'method' => 'GET',
 			));
@@ -171,77 +111,78 @@ class syntax_plugin_tagfilter_compare extends DokuWiki_Syntax_Plugin {
 
             for($ii = 0; $ii < 4; $ii++) {
                 $form->addElement('<th>');
-                $form->addElement(form_makeListboxField('tagcompare_page['.$ii.']', $dropdownValues, isset($selectedValues[$ii])?$selectedValues[$ii]:null , '', '', 'tagcompare' , array()));
+                $form->addElement(form_makeListboxField('tagcompare_page['.$ii.']', $dropdownValues, $selectedValues[$ii] ?? null, '', '', 'tagcompare' , array()));
                 $form->addElement('</th>');
             }
             $form->addElement('</tr>');
             $form->addElement('</thead>');
-            
+
 			$form->addElement('<tbody>');
-			
+
 			if($flags['images']) {
-			    /** @var $HPageimage helper_plugin_pageimage */
+			    /** @var helper_plugin_pageimage $HPageimage */
 			    $HPageimage = $this->loadHelper('pageimage');
     			$form->addElement('<tr>');
     			$form->addElement('<th></th>');
     			for($ii = 0; $ii < 4; $ii++) {
     			    $form->addElement('<td>');
-    			    if(isset($selectedValues[$ii]) && !empty($selectedValues[$ii])) {
-    			        $form->addElement($HPageimage->td($selectedValues[$ii],array('firstimage' => true)));
+    			    if(!empty($selectedValues[$ii])) {
+    			        $form->addElement($HPageimage->td($selectedValues[$ii], ['firstimage' => true])); //fixme pageimage->td() does not accept flags as 2nd arg.
     			    }
     			    $form->addElement('</td>');
     			}
     			$form->addElement('</tr>');
 			}
-			foreach($tagselect_r['tagPages'] as $idx => $tag_r) {
+            // for each tagexpression a row is added, where tags that match the tagexpression are shown if they are also
+            // used on the page selected for that table column
+            foreach($tagFilters['pagesPerMatchedTags'] as $idx => $pagesPerMatchedTag) {
 			    $form->addElement('<tr>');
 			    $form->addElement('<th>');
-			    $form->addElement(hsc($tagselect_r['label'][$idx]));
+			    $form->addElement(hsc($tagFilters['label'][$idx]));
 			    $form->addElement('</th>');
-			    
+
 			    for($ii = 0; $ii < 4; $ii++) {
 			        $form->addElement('<td>');
-			        foreach($tag_r as $tagName => $tags) {
-    			        if(in_array($selectedValues[$ii],$tags)) {
+                    //more tags per cell(=per page) possible
+			        foreach($pagesPerMatchedTag as $tagName => $pageidsPerTag) {
+    			        if(isset($selectedValues[$ii]) & in_array($selectedValues[$ii], $pageidsPerTag)) {
     			             $form->addElement(hsc($Htagfilter->getTagLabel($tagName)). '<br>');
     			        }
 			        }
 			        $form->addElement('</td>');
 			    }
-			    
+
 			    $form->addElement('</tr>');
 			}
-			
+
 			$form->addElement('<tr>');
 			$form->addElement('<th>');
 			$form->addElement('Link');
 			$form->addElement('</th>');
-			
+
 			for($ii = 0; $ii < 4; $ii++) {
-			
+
 			    $form->addElement('<th>');
-			     
-			    if(isset($selectedValues[$ii]) && !empty($selectedValues[$ii])) {
-			     $form->addElement('<a href="'.wl($selectedValues[$ii]).'" class="wikilink1">Link</a>');
-			    }
-			
+
+                if (!empty($selectedValues[$ii])) {
+                    $form->addElement('<a href="' . wl($selectedValues[$ii]) . '" class="wikilink1">Link</a>');
+                }
+
 			    $form->addElement('</th>');
-			
+
 			}
 			$form->addElement('</tr>');
-			
+
 			$form->addElement('</tbody>');
 			$form->addElement('</table>');
 			$form->addElement('</div>');
-			
+
 
 			$renderer->doc .= $form->getForm();
-		}	
+		}
 		return true;
 	}
-	
 
-	
+
+
 }
-
-//Setup VIM: ex: et ts=4 enc=utf-8 :

--- a/syntax/filter.php
+++ b/syntax/filter.php
@@ -145,8 +145,6 @@ class syntax_plugin_tagfilter_filter extends DokuWiki_Syntax_Plugin {
 		if($format === 'xhtml') {
 			$renderer->nocache();
 
-			/* @var helper_plugin_tagfilter $Htagfilter */
-			$Htagfilter = $this->loadHelper('tagfilter');
 			$renderer->cdata("\n");
 
             $depends = [
@@ -202,164 +200,181 @@ class syntax_plugin_tagfilter_filter extends DokuWiki_Syntax_Plugin {
 
 
 			if(!$htmlPerUserCache->useCache(['files'=> [$filterDataCache->cache]])) {
-				$output = '';
-
-				//check for read access
-				foreach($allPageids as $key => $pageid) {
-					if(!$Htagfilter->canRead($pageid)) {
-						unset($allPageids[$key]);
-					}
-				}
-
-				//check tags for visibility
-				foreach($tagFilters['pagesPerMatchedTags'] as &$pagesPerMatchedTag) {
-				    if(!is_array($pagesPerMatchedTag)) {
-                        $pagesPerMatchedTag = [];
-                    }
-					foreach($pagesPerMatchedTag as $tag=>$pageidsPerTag) {
-						if(count(array_intersect($pageidsPerTag, $allPageids)) == 0) {
-							unset($pagesPerMatchedTag[$tag]);
-						}
-					}
-				}
-                unset($pagesPerMatchedTag);
-
-				foreach($preparedPages as $key=>$page) {
-					if(!in_array($page['id'],$allPageids)) {
-						unset($preparedPages[$key]);
-					}
-				}
-
-				$form = new Doku_Form(array(
-					'id'=>'tagdd_'.$opt['id'],
-					'data-idx'=>$opt['id'],
-					'data-plugin'=>'tagfilter',
-					'data-tags' => json_encode($tagFilters['pagesPerMatchedTags']),
-				));
-				$output .= "\n";
-				//Fieldset manuell hinzufügen da ein style Parameter übergeben werden soll
-				$form->addElement(array(
-						'_elem'=>'openfieldset',
-						'_legend'=>'Tagfilter',
-						'style'=>'text-align:left;width:99%',
-						'id'=>'__tagfilter_'.$opt['id'],
-						'class'=>($flags['labels']!==false)?'':'hidelabel',
-
-				));
-				$form->_infieldset=true; //Fieldset starten
-
-				if($flags['pagesearch']){
-					$label = $flags['pagesearchlabel'];
-
-					$pagetitles = [];
-					foreach($allPageids as $pageid) {
-						$pagetitles[$pageid] = $Htagfilter->getPageTitle($pageid);
-					}
-					asort($pagetitles, SORT_NATURAL|SORT_FLAG_CASE);
-
-					$selectedTags = [];
-					$id = '__tagfilter_page_'.$opt['id'];
-
-					$attrs = [//generelle Optionen für DropDownListe onchange->submit von id namespace und den flags für pagelist
-						'onChange'=>'tagfilter_submit('.$opt['id'].','.json_encode($opt['ns']).','.json_encode([$opt['pagelistFlags'],$flags]).')',
-						'class'=>'tagdd_select tagfilter tagdd_select_'.$opt['id']  . ($flags['chosen']?' chosen':''),
-						'data-placeholder'=>hsc($label.' '.$this->getLang('choose')),
-						'data-label'=>hsc(utf8_strtolower(trim($label))),
-                    ];
-					if($flags['multi']){ //unterscheidung ob Multiple oder Single
-						$attrs['multiple']='multiple';
-						$attrs['size']=$this->getConf("DropDownList_size");
-					} else {
-						$attrs['size']=1;
-						$pagetitles = array_reverse($pagetitles,true);
-						$pagetitles['']='';
-						$pagetitles = array_reverse($pagetitles,true);
-					}
-					$form->addElement(form_makeListboxField($label, $pagetitles, $selectedTags , $label, $id, 'tagfilter', $attrs));
-				}
-				$output .= '<script type="text/javascript">/*<![CDATA[*/ var tagfilter_container = {}; /*!]]>*/</script>'."\n";
-				//$output .= '<script type="text/javascript">/*<![CDATA[*/ '.'tagfilter_container.tagfilter_'.$opt['id'].' = '.json_encode($tagFilters['tags2']).'; /*!]]>*/</script>'."\n";
-                foreach($tagFilters['pagesPerMatchedTags'] as $key=> $pagesPerMatchedTag){
-					$id=false;
-					$label = $tagFilters['label'][$key];
-					$selectedTags = $tagFilters['selectedTags'][$key];
-
-					//get tag labels
-					$tags = [];
-
-					foreach(array_keys($pagesPerMatchedTag) as $tagid) {
-						$tags[$tagid] = $Htagfilter->getTagLabel($tagid);
-					}
-
-					foreach($selectedTags as &$item) {
-						$item = utf8_strtolower(trim($item));
-					} unset($item);
-
-
-					$attrs = [//generelle Optionen für DropDownListe onchange->submit von id namespace und den flags für pagelist
-						'onChange'=>'tagfilter_submit('.$opt['id'].','.json_encode($opt['ns']).','.json_encode([$opt['pagelistFlags'],$flags]).')',
-						'class'=>'tagdd_select tagfilter tagdd_select_'.$opt['id'] . ($flags['chosen']?' chosen':''),
-						'data-placeholder'=>hsc($label.' '.$this->getLang('choose')),
-						'data-label'=>hsc(str_replace(' ','_',utf8_strtolower(trim($label)))),
-
-                    ];
-					if($flags['multi']){ //unterscheidung ob Multiple oder Single
-						$attrs['multiple']='multiple';
-						$attrs['size']=$this->getConf("DropDownList_size");
-					} else {
-						$attrs['size']=1;
-						$tags = array_reverse($tags,true);
-						$tags['']='';
-						$tags = array_reverse($tags,true);
-					}
-
-					if($flags['chosen']){
-						$links = array();
-						foreach($tags as $k=>$t){
-							$links[$k]=array(
-								'link'=>$Htagfilter->getImageLinkByTag($k),
-							);
-						}
-						$jsVar = 'tagfilter_jsVar_'.rand();
-						$output .= '<script type="text/javascript">/*<![CDATA[*/ tagfilter_container.'.$jsVar.' ='
-											.json_encode($links).
-											'; /*!]]>*/</script>'."\n";
-
-						$id='__tagfilter_'.$opt["id"].'_'.rand();
-
-						if($flags['tagimage']){
-						    $attrs['data-tagimage'] = $jsVar;
-						}
-
-					}
-					$form->addElement(form_makeListboxField($label, $tags, $selectedTags , $label, $id, 'tagfilter' , $attrs));
-				}
-
-				$form->addElement(form_makeButton('button','', $this->getLang('Delete filter'), array('onclick'=>'tagfilter_cleanform('.$opt['id'].',true)')));
-				if($flags['count']) {
-				    $form->addElement('<div class="tagfilter_count">'.$this->getLang('found_count').': ' . '<span class="tagfilter_count_number"></span></div>');
-				}
-				$form->endFieldset();
-				$output .= $form->getForm();//Form Ausgeben
-
-				$output.= "<div id='tagfilter_ergebnis_".$opt['id']."' class='tagfilter'>";
-				//dbg($opt['pagelistFlags']);
-				$output .= $HtagfilterSyntax->renderList($preparedPages,$flags, $opt['pagelistFlags']);
-				$output.= "</div>";
-
-				$htmlPerUserCache->storeCache($output);
-
+                $html = $this->htmlOutput($tagFilters, $allPageids, $preparedPages, $opt);
+                $htmlPerUserCache->storeCache($html);
 			} else {
-				$output =$htmlPerUserCache->retrieveCache();
+                $html =$htmlPerUserCache->retrieveCache();
 			}
 
-			$renderer->doc .= $output;
+			$renderer->doc .= $html;
         }
 		return true;
 	}
 
+    /**
+     * Returns html of the tagfilter form
+     *
+     * @param array $tagFilters
+     * @param array $allPageids
+     * @param array $preparedPages
+     * @param array $opt option array from the handler
+     * @return string
+     */
+    private function htmlOutput($tagFilters, $allPageids, $preparedPages, array $opt)
+    {
+        /* @var helper_plugin_tagfilter $Htagfilter */
+        $Htagfilter = $this->loadHelper('tagfilter');
+        /* @var  helper_plugin_tagfilter_syntax $HtagfilterSyntax */
+        $HtagfilterSyntax = $this->loadHelper('tagfilter_syntax');
+        $flags = $opt['tagfilterFlags'];
 
+        $output = '';
+
+        //check for read access
+        foreach ($allPageids as $key => $pageid) {
+            if (!$Htagfilter->canRead($pageid)) {
+                unset($allPageids[$key]);
+            }
+        }
+
+        //check tags for visibility
+        foreach ($tagFilters['pagesPerMatchedTags'] as &$pagesPerMatchedTag) {
+            if (!is_array($pagesPerMatchedTag)) {
+                $pagesPerMatchedTag = [];
+            }
+            foreach ($pagesPerMatchedTag as $tag => $pageidsPerTag) {
+                if (count(array_intersect($pageidsPerTag, $allPageids)) == 0) {
+                    unset($pagesPerMatchedTag[$tag]);
+                }
+            }
+        }
+        unset($pagesPerMatchedTag);
+
+        foreach ($preparedPages as $key => $page) {
+            if (!in_array($page['id'], $allPageids)) {
+                unset($preparedPages[$key]);
+            }
+        }
+
+        $form = new Doku_Form(array(
+            'id' => 'tagdd_' . $opt['id'],
+            'data-idx' => $opt['id'],
+            'data-plugin' => 'tagfilter',
+            'data-tags' => json_encode($tagFilters['pagesPerMatchedTags']),
+        ));
+        $output .= "\n";
+        //Fieldset manuell hinzufügen da ein style Parameter übergeben werden soll
+        $form->addElement(array(
+            '_elem' => 'openfieldset',
+            '_legend' => 'Tagfilter',
+            'style' => 'text-align:left;width:99%',
+            'id' => '__tagfilter_' . $opt['id'],
+            'class' => ($flags['labels'] !== false) ? '' : 'hidelabel',
+
+        ));
+        $form->_infieldset = true; //Fieldset starten
+
+        if ($flags['pagesearch']) {
+            $label = $flags['pagesearchlabel'];
+
+            $pagetitles = [];
+            foreach ($allPageids as $pageid) {
+                $pagetitles[$pageid] = $Htagfilter->getPageTitle($pageid);
+            }
+            asort($pagetitles, SORT_NATURAL | SORT_FLAG_CASE);
+
+            $selectedTags = [];
+            $id = '__tagfilter_page_' . $opt['id'];
+
+            $attrs = [//generelle Optionen für DropDownListe onchange->submit von id namespace und den flags für pagelist
+                'onChange' => 'tagfilter_submit(' . $opt['id'] . ',' . json_encode($opt['ns']) . ',' . json_encode([$opt['pagelistFlags'], $flags]) . ')',
+                'class' => 'tagdd_select tagfilter tagdd_select_' . $opt['id'] . ($flags['chosen'] ? ' chosen' : ''),
+                'data-placeholder' => hsc($label . ' ' . $this->getLang('choose')),
+                'data-label' => hsc(utf8_strtolower(trim($label))),
+            ];
+            if ($flags['multi']) { //unterscheidung ob Multiple oder Single
+                $attrs['multiple'] = 'multiple';
+                $attrs['size'] = $this->getConf("DropDownList_size");
+            } else {
+                $attrs['size'] = 1;
+                $pagetitles = array_reverse($pagetitles, true);
+                $pagetitles[''] = '';
+                $pagetitles = array_reverse($pagetitles, true);
+            }
+            $form->addElement(form_makeListboxField($label, $pagetitles, $selectedTags, $label, $id, 'tagfilter', $attrs));
+        }
+        $output .= '<script type="text/javascript">/*<![CDATA[*/ var tagfilter_container = {}; /*!]]>*/</script>' . "\n";
+        //$output .= '<script type="text/javascript">/*<![CDATA[*/ '.'tagfilter_container.tagfilter_'.$opt['id'].' = '.json_encode($tagFilters['tags2']).'; /*!]]>*/</script>'."\n";
+        foreach ($tagFilters['pagesPerMatchedTags'] as $key => $pagesPerMatchedTag) {
+            $id = false;
+            $label = $tagFilters['label'][$key];
+            $selectedTags = $tagFilters['selectedTags'][$key];
+
+            //get tag labels
+            $tags = [];
+
+            foreach (array_keys($pagesPerMatchedTag) as $tagid) {
+                $tags[$tagid] = $Htagfilter->getTagLabel($tagid);
+            }
+
+            foreach ($selectedTags as &$item) {
+                $item = utf8_strtolower(trim($item));
+            }
+            unset($item);
+
+
+            $attrs = [//generelle Optionen für DropDownListe onchange->submit von id namespace und den flags für pagelist
+                'onChange' => 'tagfilter_submit(' . $opt['id'] . ',' . json_encode($opt['ns']) . ',' . json_encode([$opt['pagelistFlags'], $flags]) . ')',
+                'class' => 'tagdd_select tagfilter tagdd_select_' . $opt['id'] . ($flags['chosen'] ? ' chosen' : ''),
+                'data-placeholder' => hsc($label . ' ' . $this->getLang('choose')),
+                'data-label' => hsc(str_replace(' ', '_', utf8_strtolower(trim($label)))),
+
+            ];
+            if ($flags['multi']) { //unterscheidung ob Multiple oder Single
+                $attrs['multiple'] = 'multiple';
+                $attrs['size'] = $this->getConf("DropDownList_size");
+            } else {
+                $attrs['size'] = 1;
+                $tags = array_reverse($tags, true);
+                $tags[''] = '';
+                $tags = array_reverse($tags, true);
+            }
+
+            if ($flags['chosen']) {
+                $links = array();
+                foreach ($tags as $k => $t) {
+                    $links[$k] = array(
+                        'link' => $Htagfilter->getImageLinkByTag($k),
+                    );
+                }
+                $jsVar = 'tagfilter_jsVar_' . rand();
+                $output .= '<script type="text/javascript">/*<![CDATA[*/ tagfilter_container.' . $jsVar . ' ='
+                    . json_encode($links) .
+                    '; /*!]]>*/</script>' . "\n";
+
+                $id = '__tagfilter_' . $opt["id"] . '_' . rand();
+
+                if ($flags['tagimage']) {
+                    $attrs['data-tagimage'] = $jsVar;
+                }
+
+            }
+            $form->addElement(form_makeListboxField($label, $tags, $selectedTags, $label, $id, 'tagfilter', $attrs));
+        }
+
+        $form->addElement(form_makeButton('button', '', $this->getLang('Delete filter'), array('onclick' => 'tagfilter_cleanform(' . $opt['id'] . ',true)')));
+        if ($flags['count']) {
+            $form->addElement('<div class="tagfilter_count">' . $this->getLang('found_count') . ': ' . '<span class="tagfilter_count_number"></span></div>');
+        }
+        $form->endFieldset();
+        $output .= $form->getForm();//Form Ausgeben
+
+        $output .= "<div id='tagfilter_ergebnis_" . $opt['id'] . "' class='tagfilter'>";
+        //dbg($opt['pagelistFlags']);
+        $output .= $HtagfilterSyntax->renderList($preparedPages, $flags, $opt['pagelistFlags']);
+        $output .= "</div>";
+
+        return $output;
+    }
 
 }
-
-//Setup VIM: ex: et ts=4 enc=utf-8 :


### PR DESCRIPTION
Unfortunately in the earlier commits I mixed up already some reformatting stuff. So probably not that readable.

Improves php8 support by ensuring that at more places variables are defined.

Fixes #11 because mbstring function are replaced by DokuWiki's PHPString class, which has fallback for mbstring.
Fixes #23 by merging config file array