### PR TITLE
collaboration tagfilter <-> include plugins?

### DIFF
--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -237,6 +237,7 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
             'images' => false,
             'count' => false,
             'tagintersect' => false,
+            'include' => false,
         ];
         if (!is_array($flags)) {
             return $conf;
@@ -300,6 +301,9 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     break;
                 case 'tagintersect':
                     $conf['tagintersect'] = true;
+                    break;
+                case 'include':
+                    $conf['include'] = true;
                     break;
             }
         }

--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -307,6 +307,7 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     break;
                 case 'sortbypageid':
                     $conf['sortbypageid'] = true;
+                    break;
                 case 'include':
                     $conf['include'] = explode(';', $value);
                     break;

--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -237,7 +237,7 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
             'images' => false,
             'count' => false,
             'tagintersect' => false,
-            'include' => false,
+            'include' => [],
         ];
         if (!is_array($flags)) {
             return $conf;
@@ -303,7 +303,7 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
                     $conf['tagintersect'] = true;
                     break;
                 case 'include':
-                    $conf['include'] = true;
+                    $conf['include'] = explode(';', $value);
                     break;
             }
         }

--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -213,10 +213,10 @@ class helper_plugin_tagfilter_syntax extends DokuWiki_Plugin
      *
      * @param array $flags array with (all optional):
      *      multi, chosen, tagimage, pagesearch, cacheage, nocache, rsort, nolabels, noneonclear, tagimagecolumn,
-     *      tagcolumn, excludeNs, withTags, excludeTags, images, count, tagintersect
+     *      tagcolumn, excludeNs, withTags, excludeTags, images, count, tagintersect, include
      * @return array tagfilter flags with:
      *      multi, chosen, tagimage, pagesearch, pagesearchlabel, cache, rsort, labels, noneonclear, tagimagecolumn,
-     *      tagcolumn (optional), excludeNs, withTags, excludeTags, images, count, tagintersect
+     *      tagcolumn (optional), excludeNs, withTags, excludeTags, images, count, tagintersect, include
      */
     public function parseFlags($flags)
     {

--- a/script.js
+++ b/script.js
@@ -108,7 +108,11 @@ function tagfilter_submit(id,ns,flags)
 
 	//loop all found searchentries
 	document
-		.querySelectorAll('#tagfilter_ergebnis_'+id+'.tagfilter :is(ul > li, table tr, div.plugin_include_content)')
+		.querySelectorAll(`
+			#tagfilter_ergebnis_${id}.tagfilter > ul > li,
+			#tagfilter_ergebnis_${id}.tagfilter > div.table > table.inline tr,
+			#tagfilter_ergebnis_${id}.tagfilter > div.plugin_include_content
+		`)
 		.forEach(elt => {
 			let pageId;
 			switch(elt.nodeName) {

--- a/syntax/filter.php
+++ b/syntax/filter.php
@@ -239,13 +239,19 @@ class syntax_plugin_tagfilter_filter extends DokuWiki_Syntax_Plugin
      */
     private function htmlOutput($tagFilters, $allPageids, $preparedPages, array $opt)
     {
+        // attention: htmlPrepareOutput modifies $tagFilters, $allPageids, $preparedPages.
+        $this->htmlPrepareOutput($tagFilters, $allPageids, $preparedPages, $opt);
+
+        $output = $this->htmlFormOutput($tagFilters, $allPageids, $opt)
+            . $this->htmlPagelistOutput($preparedPages, $opt);
+
+        return $output;
+    }
+
+    private function htmlPrepareOutput(&$tagFilters, &$allPageids, &$preparedPages, array $opt)
+    {
         /* @var helper_plugin_tagfilter $Htagfilter */
         $Htagfilter = $this->loadHelper('tagfilter');
-        /* @var  helper_plugin_tagfilter_syntax $HtagfilterSyntax */
-        $HtagfilterSyntax = $this->loadHelper('tagfilter_syntax');
-        $flags = $opt['tagfilterFlags'];
-
-        $output = '';
 
         //check for read access
         foreach ($allPageids as $key => $pageid) {
@@ -272,6 +278,14 @@ class syntax_plugin_tagfilter_filter extends DokuWiki_Syntax_Plugin
                 unset($preparedPages[$key]);
             }
         }
+    }
+
+    private function htmlFormOutput($tagFilters, $allPageids, array $opt) {
+        /* @var helper_plugin_tagfilter $Htagfilter */
+        $Htagfilter = $this->loadHelper('tagfilter');
+
+        $flags = $opt['tagfilterFlags'];
+        $output = '';
 
         $form = new Doku_Form([
             'id' => 'tagdd_' . $opt['id'],
@@ -386,9 +400,18 @@ class syntax_plugin_tagfilter_filter extends DokuWiki_Syntax_Plugin
         $form->endFieldset();
         $output .= $form->getForm();//Form Ausgeben
 
+        return $output;
+    }
+
+    private function htmlPagelistOutput($preparedPages, array $opt) {
+        /* @var  helper_plugin_tagfilter_syntax $HtagfilterSyntax */
+        $HtagfilterSyntax = $this->loadHelper('tagfilter_syntax');
+
+        $output = '';
+
         $output .= "<div id='tagfilter_ergebnis_" . $opt['id'] . "' class='tagfilter'>";
         //dbg($opt['pagelistFlags']);
-        $output .= $HtagfilterSyntax->renderList($preparedPages, $flags, $opt['pagelistFlags']);
+        $output .= $HtagfilterSyntax->renderList($preparedPages, $opt['tagfilterFlags'], $opt['pagelistFlags']);
         $output .= "</div>";
 
         return $output;


### PR DESCRIPTION
Fixes #25.

~~Only works with include plugin PR https://github.com/dokufreaks/plugin-include/pull/296.~~
**EDIT:** Works without modification of the include plugin.

A new `include` tag is introduced with syntax
* `include`, or
* `include=semicolon;separated;include;plugin;options`

Request for comments.