### PR TITLE
fixing dokuwiki-template-bootstrap3 #600

### DIFF
--- a/script.js
+++ b/script.js
@@ -106,16 +106,16 @@ function tagfilter_submit(id,ns,flags)
 	/*
 	 * Handle all pagelist styles,
 	 * cf. https://github.com/dokufreaks/plugin-pagelist/blob/e48b7725cf940d21381ef32851bf82aa6736ee9c/helper.php#L334
-         * standard:   div.table > table.pagelist.plgn__pglist"
-	 * table:      div.table > table.inline.plgn__pglist"
-         * list:       div.table > table.ul.plgn__pglist"
+     * standard:   div > table.pagelist.plgn__pglist"
+	 * table:      div > table.inline.plgn__pglist"
+     * list:       div > table.ul.plgn__pglist"
 	 * simplelist: ul > li
 	 *
 	 * Handle include plugin style: div.plugin_include_content
 	 */
 	document
 		.querySelectorAll(`
-			#tagfilter_ergebnis_${id}.tagfilter > div.table > table.plgn__pglist > tbody > tr,
+			#tagfilter_ergebnis_${id}.tagfilter > div > table.plgn__pglist > tbody > tr,
 			#tagfilter_ergebnis_${id}.tagfilter > ul > li,
 			#tagfilter_ergebnis_${id}.tagfilter > div.plugin_include_content
 		`)


### PR DESCRIPTION
See https://github.com/giterlizzi/dokuwiki-template-bootstrap3/issues/600 : Tagfilter didn't work with the bootstrap3 template.

### Problem analysis:

- tagfilter plugin's code relies on the containing `<div>` having `class="table"`, cf. https://github.com/lisps/tagfilter/blob/a5f406a32f15ccbeb1b5f185210077309a018c61/script.js#L118 .

- the bootstrap3 plugin changes that class, cf. https://github.com/giterlizzi/dokuwiki-template-bootstrap3/blob/b1c8c9aa7c0663a9edd387b9901e62c022896e31/Template.php#L1547-L1549


### Solutions
This is a fix for it.
However may I ask: Can arbitrary similar problems occur with other templates?